### PR TITLE
0.2.0 final fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
   - docker
 
 before_install:
-  - git clone  git://github.com/openmicroscopy/omero-test-infra .omero
+  - git clone git://github.com/sbesson/omero-test-infra -b PLUGIN_envvar .omero
 
 script:
   - .omero/cli-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ virtualenv:
 
 sudo: required
 
+env: PLUGIN=metadata
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
   - docker
 
 before_install:
-  - git clone git://github.com/sbesson/omero-test-infra -b PLUGIN_envvar .omero
+  - git clone  git://github.com/openmicroscopy/omero-test-infra .omero
 
 script:
   - .omero/cli-docker

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
-.. image:: https://travis-ci.org/ome/omero-cli-metadata.svg?branch=master
-    :target: https://travis-ci.org/ome/omero-cli-metadata
+.. image:: https://travis-ci.org/ome/omero-metadata.svg?branch=master
+    :target: https://travis-ci.org/ome/omero-metadata
 
-.. image:: https://badge.fury.io/py/omero-cli-metadata.svg
-    :target: https://badge.fury.io/py/omero-cli-metadata
+.. image:: https://badge.fury.io/py/omero-metadata.svg
+    :target: https://badge.fury.io/py/omero-metadata
 
-omero-cli-metadata
-==================
+OMERO metadata plugin
+=====================
 
 Plugin for use in the OMERO CLI.
 
@@ -25,7 +25,7 @@ Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
 
 ::
 
-    $ pip install -U omero-cli-metadata
+    $ pip install -U omero-metadata
 
 License
 -------

--- a/setup.py
+++ b/setup.py
@@ -91,14 +91,14 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.1.0.dev1'
-url = "https://github.com/ome/omero-cli-metadata/"
+version = '0.2.0.dev1'
+url = "https://github.com/ome/omero-metadata/"
 
 setup(
     version=version,
     packages=['', 'omero.plugins'],
     package_dir={"": "src"},
-    name='omero-cli-metadata',
+    name='omero-metadata',
     description="Metadata plugin for use in the OMERO CLI.",
     long_description=read('README.rst'),
     classifiers=[


### PR DESCRIPTION
Final adjustements to this  repository in order to release `omero-metadata` 0.2.0 to PyPI.

The main adjustements are related to the renaming of this repository from `omero-cli-metadata` to `omero-metadata` and the corresponding adjustments in `omero-test-infra`