### PR TITLE
0.2.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,19 @@
+CHANGES
+=======
+
+0.2.0
+-----
+
+This release contains the metadata code matching the state of OMERO 5.4.7.
+
+* Add metadata code filtered from the develop branch of
+  openmicroscopy/openmicroscopy
+* Remove OMERO_DEV_PLUGINS variable
+* Add infrastructure for releasing the module to PyPI
+* Activate Travis CI for running the integration tests using omero-test-infra
+
+0.1.0
+-----
+
+* Filter metadata code from the metadata53 branch of
+  openmicroscopy/openmicroscopy

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,11 @@ Install the command-line tool using `pip <https://pip.pypa.io/en/stable/>`_:
 
     $ pip install -U omero-metadata
 
+Note the original version of this code is still available as deprecated code in
+version 5.4.x of OMERO.py. When using the CLI metadata plugin, the
+`OMERO_DEV_PLUGINS` environment variable should not be set to prevent
+conflicts when importing the Python module.
+
 License
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.2.0.dev1'
+version = '0.2.0'
 url = "https://github.com/ome/omero-metadata/"
 
 setup(


### PR DESCRIPTION
- Add minimal CHANGES.rst  describing the relationship of omero-metadata:0.2.0 compared to OMERO 5.4.7
- Add warning about the usage of `OMERO_DEV_PLUGINS` when using the CLI metadata plugin
- Bump the version to 0.2.0

The filter branch statement can be verified by downloading the source of OMERO 5.4.7 and diffing the relevant files:

```
sbesson@lifesci-82385:omero-metadata (master) $ diff src/omero_cli_metadata.py /tmp/openmicroscopy-5.4.7/components/tools/OmeroPy/src/omero/plugins/metadata.py 
23,24c23
< import populate_metadata
< from omero.util import populate_roi, pydict_text_io
---
> from omero.util import populate_metadata, populate_roi, pydict_text_io
628a628,636
> 
> try:
>     if "OMERO_DEV_PLUGINS" in os.environ:
>         register("metadata", MetadataControl, HELP)
> except NameError:
>     if __name__ == "__main__":
>         cli = CLI()
>         cli.register("metadata", MetadataControl, HELP)
>         cli.invoke(sys.argv[1:])
sbesson@lifesci-82385:omero-metadata (master) $ diff src/populate_metadata.py /tmp/openmicroscopy-5.4.7/components/tools/OmeroPy/src/omero/util/populate_metadata.py 
57c57
< from omero.util.populate_roi import ThreadPool
---
> from populate_roi import ThreadPool
```