### PR TITLE
Image column name

### DIFF
--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -280,7 +280,7 @@ class HeaderResolver(object):
                               self.DEFAULT_COLUMN_SIZE, list()))
             # Currently hard-coded, but "if image name, then add image id"
             if column.name == IMAGE_NAME_COLUMN:
-                append.append(ImageColumn("image", '', list()))
+                append.append(ImageColumn("Image", '', list()))
         columns.extend(append)
         self.columns_sanity_check(columns)
         return columns

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -705,6 +705,7 @@ class Dataset2Images(Fixture):
             img = mv['Image Name']
             con = mv['Concentration']
             typ = mv['Type']
+            assert 'Image' in mv
             assert img[0] in ("A", "a")
             which = long(img[1:])
             if which % 2 == 1:


### PR DESCRIPTION
Fixes #9 - see also discussion at https://github.com/openmicroscopy/openmicroscopy/pull/5832

## Summary

This PR addresses a discrepancy in the naming of the image ID column for Project/Dataset hierarchies:

- when a bulk annotation is created from a CSV file where images are specified via ID via an `Image` column, an `Image` column is created in the OMERO.table
- when a bulk annotation is created from a CSV file where images are specified via name via an `Image Name` column, an `image` column is created in the OMERO.table

To reduce the cost on clients to support both forms, this PR proposes to unify the column name and use `Image` in agreement with the naming of other columns like `Well`, `Plate`.

## Integration tests

ae81898 fixes the tests to use the local classes rather than the upstream deprecated `omero.util` classes.  857ee65 adds a test asserting the `Image` column exists when a bulk annotation is created for a project or a dataset.

## Functional testing

A good public example of annotation affected by this PR is the [annotation CSV file for idr0021](https://github.com/IDR/idr0021-lawo-pericentriolarmaterial/blob/master/experimentA/idr0021-experimentA-annotation.csv).

To test this PR:
- use a server where `idr0021-lawo-pericentriolarmaterial/experimentA` is imported
- if necessary delete the existing project bulk annotation
- checkout this branch and install the module using `python setup.py install`
- populate the metadata for the project using the file above and `bin/omero metadata populate`
- either download the annotation file and check it contains a column called `Image` using e.g. `h5dump`
- or if https://github.com/openmicroscopy/openmicroscopy/pull/5832 is deployed, open one of the images under a dataset, load the Tables tab and check the tables is displayed with a row of key `Image`

## Impact

Main impact of this PR is that every bulk annotation created with a previous version of this plugin and `Image Name` columns might require to be re-generated (or the column name updated).
Proposed tag: `0.2.3` if we consider this as a bug or `0.3.0` if we consider this as a breaking change.
