### PR TITLE
Implement dry-run option in delete map context class

### DIFF
--- a/src/omero_cli_metadata.py
+++ b/src/omero_cli_metadata.py
@@ -478,11 +478,10 @@ class MetadataControl(BaseControl):
 
         loops = 0
         ms = 0
-        if not args.dry_run:
-            wait = args.wait
-            if wait:
-                ms = 5000
-                loops = int((wait * 1000) / ms) + 1
+        wait = args.wait
+        if wait:
+            ms = 5000
+            loops = int((wait * 1000) / ms) + 1
 
         # Note some contexts only support a subset of these args
         ctx = context_class(client, args.obj, file=args.file, fileid=fileid,

--- a/src/omero_cli_metadata.py
+++ b/src/omero_cli_metadata.py
@@ -488,7 +488,7 @@ class MetadataControl(BaseControl):
         ctx = context_class(client, args.obj, file=args.file, fileid=fileid,
                             cfg=args.cfg, cfgid=cfgid, attach=args.attach,
                             options=localcfg, batch_size=args.batch,
-                            loops=loops, ms=ms)
+                            loops=loops, ms=ms, dry_run=args.dry_run)
         ctx.parse()
 
     def rois(self, args):

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -1899,7 +1899,7 @@ class DeleteMapAnnotationContext(_QueryContext):
             deleted = rsp.deletedObjects
             log.info("Deleted objects in %g s" % (time.time() - start))
             for k, v in deleted.iteritems():
-                log.info("  %d %s", k, len(v))
+                log.info("  %d %s", len(v), k)
                 log.debug("  %s %s", k, v)
         except AttributeError:
             log.error("Delete failed: %s", rsp)

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -1884,11 +1884,10 @@ class DeleteMapAnnotationContext(_QueryContext):
         import time
         del_cmd = omero.cmd.Delete2(targetObjects=to_delete,
                                     dryRun=self.dry_run)
+        start = time.time()
         try:
-            start = time.time()
             callback = self.client.submit(
                 del_cmd, loops=loops, ms=ms, failontimeout=True)
-            log.debug("Delete completed in %g s" % (time.time() - start))
         except CmdError, ce:
             log.error("Failed to delete: %s" % to_delete)
             raise Exception(ce.err)
@@ -1898,9 +1897,10 @@ class DeleteMapAnnotationContext(_QueryContext):
         rsp = callback.getResponse()
         try:
             deleted = rsp.deletedObjects
+            log.info("Deleted objects in %g s" % (time.time() - start))
             for k, v in deleted.iteritems():
-                log.info("Deleted: %s %d", k, len(v))
-                log.debug("Deleted: %s %s", k, v)
+                log.info("  %d %s", k, len(v))
+                log.debug("  %s %s", k, v)
         except AttributeError:
             log.error("Delete failed: %s", rsp)
 

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -1881,7 +1881,8 @@ class DeleteMapAnnotationContext(_QueryContext):
                                        self.loops, self.ms)
 
     def _write_to_omero_batch(self, to_delete, loops=10, ms=500):
-        del_cmd = omero.cmd.Delete2(targetObjects=to_delete)
+        del_cmd = omero.cmd.Delete2(targetObjects=to_delete,
+                                    dryRun=self.dry_run)
         try:
             callback = self.client.submit(
                 del_cmd, loops=loops, ms=ms, failontimeout=True)

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -1882,8 +1882,11 @@ class DeleteMapAnnotationContext(_QueryContext):
 
     def _write_to_omero_batch(self, to_delete, loops=10, ms=500):
         import time
-        del_cmd = omero.cmd.Delete2(targetObjects=to_delete,
-                                    dryRun=self.dry_run)
+        del_cmd = omero.cmd.Delete2(
+            targetObjects=to_delete,
+            childOptions=self.options.get("childOptions", None),
+            dryRun=self.dry_run,
+            typesToIgnore=self.options.get("typesToIgnore", None))
         start = time.time()
         try:
             callback = self.client.submit(

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -860,7 +860,8 @@ class ParsingContext(object):
 
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, column_types=None,
-                 options=None, batch_size=1000, loops=10, ms=500):
+                 options=None, batch_size=1000, loops=10, ms=500,
+                 dry_run=False):
         '''
         This lines should be handled outside of the constructor:
 
@@ -882,6 +883,7 @@ class ParsingContext(object):
         self.parsing_util_factory = ParsingUtilFactory(client,
                                                        target_object,
                                                        self.value_resolver)
+        self.dry_run = dry_run
 
     def create_annotation_link(self):
         self.target_class = self.target_object.__class__
@@ -1380,6 +1382,7 @@ class BulkToMapAnnotationContext(_QueryContext):
             self.batch_size = batch_size
         else:
             self.batch_size = 1000
+        self.dry_run = dry_run
 
     def _init_namespace_primarykeys(self):
         try:
@@ -1701,6 +1704,7 @@ class DeleteMapAnnotationContext(_QueryContext):
             self.batch_size = 1000
         self.loops = loops
         self.ms = ms
+        self.dry_run = dry_run
 
     def parse(self):
         self.populate()

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -1881,11 +1881,14 @@ class DeleteMapAnnotationContext(_QueryContext):
                                        self.loops, self.ms)
 
     def _write_to_omero_batch(self, to_delete, loops=10, ms=500):
+        import time
         del_cmd = omero.cmd.Delete2(targetObjects=to_delete,
                                     dryRun=self.dry_run)
         try:
+            start = time.time()
             callback = self.client.submit(
                 del_cmd, loops=loops, ms=ms, failontimeout=True)
+            log.debug("Delete completed in %g s" % (time.time() - start))
         except CmdError, ce:
             log.error("Failed to delete: %s" % to_delete)
             raise Exception(ce.err)

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -964,12 +964,16 @@ class TestPopulateMetadataHelper(ITest):
         cfg = fixture.get_cfg()
 
         target = fixture.get_target()
-        ctx = DeleteMapAnnotationContext(self.client, target,
-                                         cfg=cfg, batch_size=batch_size)
+        ctx = DeleteMapAnnotationContext(
+            self.client, target, cfg=cfg, batch_size=batch_size, dry_run=True)
 
         assert len(fixture.get_child_annotations()) == fixture.ann_count
         ctx.parse()
 
+        ctx = DeleteMapAnnotationContext(
+            self.client, target, cfg=cfg, batch_size=batch_size)
+        assert len(fixture.get_child_annotations()) == fixture.ann_count
+        ctx.parse()
         assert len(fixture.get_child_annotations()) == 0
         assert len(fixture.get_all_map_annotations()) == 0
 
@@ -1263,10 +1267,16 @@ class TestPopulateMetadataConfigFiles(TestPopulateMetadataHelperPerMethod):
         if ns:
             options['ns'] = ns
         ctx = DeleteMapAnnotationContext(
-            self.client, target, attach=attach, options=options)
+            self.client, target, attach=attach, options=options, dry_run=True)
         ctx.parse()
         after = self._get_annotations_config(fixture)
 
+        assert before[0].id == after[0].id
+        assert before[0].file.id == after[0].file.id
+
+        ctx = DeleteMapAnnotationContext(
+            self.client, target, attach=attach, options=options)
+        ctx.parse()
         if attach and ns != NSBULKANNOTATIONS:
             assert len(after) == 0
         else:

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -1277,6 +1277,7 @@ class TestPopulateMetadataConfigFiles(TestPopulateMetadataHelperPerMethod):
         ctx = DeleteMapAnnotationContext(
             self.client, target, attach=attach, options=options)
         ctx.parse()
+        after = self._get_annotations_config(fixture)
         if attach and ns != NSBULKANNOTATIONS:
             assert len(after) == 0
         else:


### PR DESCRIPTION
As a preamble of upcoming work on the performance of the map annotation delete command, this PR:

- unifies the constructor of all the `Context` classes to support a `dry_run` boolean keyword, set to `False` by default
- updates the `DeleteMapAnnotationContext` OMERO deletion method to consume the `dry_run` argument
- updates the CLI `metadata populate` command to propagate the `dry-run` argument to the context class

This should allow to use `bin/omero metadata populate --context deletemap --dry-run` to measure a baseline and compare performance metrics for variations of the deletion commands without deleting the actual annotations on the server.

17e3737 updates the integration tests for the map deletion context class to test `ctx.parse()` with and without `--dry-run`