### PR TITLE
0.3.0a1 pre-release of omero-metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ CHANGES
 0.3.0a1
 -------
 
+* Unify naming of the Image column in OMERO.tables
 * Fix CLI metadata populate --context deletemap --dry-run behavior
 * Propagate delete options in DeleteMapAnnotationContext
 * Added bulk annotations for Projects and Datasets

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,11 @@
 CHANGES
 =======
 
-0.3.0
------
+0.3.0a1
+-------
 
+* Fix CLI metadata populate --context deletemap --dry-run behavior
+* Propagate delete options in DeleteMapAnnotationContext
 * Added bulk annotations for Projects and Datasets
 * Changed csv parsing to proceed line-by-line (streaming)
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.3.0.dev1'
+version = '0.3.0a1'
 url = "https://github.com/ome/omero-metadata/"
 
 setup(


### PR DESCRIPTION
This PR proposes to release the 2 PRs currently merged in https://github.com/ome/omero-metadata/milestone/2?closed=1 and deploy it as a PyPI pre-release.

This is largely motivated by the fact working with map annotation deletion in the context of IDR now requires some of the changes included in #11 (to ignore `Annotation` during the deletion operation for primary keys)

Alternatively, a `0.3.0` release could be cut today and all future API breaking improvements moved to `0.4.0`.

/cc @dominikl @joshmoore @jburel @kkoz @emilroz 
