### PR TITLE
Allow multiple targets

### DIFF
--- a/src/omero_cli_metadata.py
+++ b/src/omero_cli_metadata.py
@@ -149,7 +149,7 @@ class ComplexProxyStringType(object):
                 else:
                     ids.append(long(id))
             return klass, ids
-        except:
+        except Exception:
             raise ValueError("Bad object: %s", arg)
 
     def __repr__(self):

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -622,8 +622,9 @@ class ScreenWrapper(SPWWrapper):
                 'where s.id = :id'), parameters, {'omero.group': '-1'})
             if target_object is None:
                 raise MetadataError('Could not find target object!')
-            self.target_names[target_object.id.val] = unwrap(target_object.getName())
-            
+            self.target_names[target_object.id.val] =\
+                unwrap(target_object.getName())
+
             images_by_id = dict()
             self.images_by_id[target_object.id.val] = images_by_id
             for plate in (l.child for l in target_object.copyPlateLinks()):
@@ -697,8 +698,8 @@ class PlateWrapper(SPWWrapper):
                 'where p.id = :id'), parameters, {'omero.group': '-1'})
             if target_object is None:
                 raise MetadataError('Could not find target object!')
-            self.target_names[target_object.id.val] = unwrap(target_object.getName())
-            
+            self.target_names[target_object.id.val] =\
+                unwrap(target_object.getName())
             wells_by_location = dict()
             wells_by_id = dict()
             images_by_id = dict()
@@ -853,8 +854,8 @@ class ProjectWrapper(PDIWrapper):
 
                 ikey = (did, iname)
                 if ikey in seen and iid != seen[ikey]:
-                    raise Exception("Duplicate image: '%s' = %s, %s (Dataset:%s)"
-                                    % (iname, seen[ikey], iid, did))
+                    raise Exception("Duplicate image: '%s' = %s, %s\
+                        (Dataset:%s)" % (iname, seen[ikey], iid, did))
                 else:
                     seen[ikey] = iid
 

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -733,7 +733,8 @@ class DatasetWrapper(PDIWrapper):
             self.target_objects[i] = unwrap(query_service.findByQuery(
                 'select d from Dataset d where d.id = :id',
                 parameters, {'omero.group': '-1'}))
-            self.target_names[target_object.id.val] = self.target_objects[i].name.val
+            self.target_names[target_object.id.val] = self.target_objects[i]\
+                                                          .name.val
 
             data = list()
             while True:
@@ -757,12 +758,12 @@ class DatasetWrapper(PDIWrapper):
                 iid = image.id.val
                 images_by_id[iid] = image
                 if iname in self.images_by_name:
-                    raise Exception("Image named %s(id=%d) present. (id=%s)" % (
-                        iname, self.images_by_name[iname], iid
-                    ))
+                    raise Exception("Image named %s(id=%d) present. (id=%s)" %
+                                    (iname, self.images_by_name[iname], iid))
                 self.images_by_name[iname] = image
             self.images_by_id[target_object.id.val] = images_by_id
-            log.debug('Completed parsing dataset: %s' % self.target_names[target_object.id.val])
+            log.debug('Completed parsing dataset: %s' %
+                      self.target_names[target_object.id.val])
 
 
 class ProjectWrapper(PDIWrapper):
@@ -922,14 +923,14 @@ class ParsingContext(object):
         self.target_ids = target_objects[1]
         self.target_objects = []
         for oid in target_objects[1]:
-          if target_objects[0] == 'Dataset':
-            self.target_objects.append(DatasetI(long(oid), False))
-          elif target_objects[0] == 'Project':
-            self.target_objects.append(ProjectI(long(oid), False))
-          elif target_objects[0] == 'Screen':
-            self.target_objects.append(ScreenI(long(oid), False))
-          elif target_objects[0] == 'Plate':
-            self.target_objects.append(PlateI(long(oid), False))
+            if target_objects[0] == 'Dataset':
+                self.target_objects.append(DatasetI(long(oid), False))
+            elif target_objects[0] == 'Project':
+                self.target_objects.append(ProjectI(long(oid), False))
+            elif target_objects[0] == 'Screen':
+                self.target_objects.append(ScreenI(long(oid), False))
+            elif target_objects[0] == 'Plate':
+                self.target_objects.append(PlateI(long(oid), False))
 
         self.file = file
         self.column_types = column_types
@@ -975,7 +976,8 @@ class ParsingContext(object):
             header_resolver = HeaderResolver(
                 target_object, header_row,
                 column_types=self.column_types)
-            self.columns[target_object.id.val] = header_resolver.create_columns()
+            self.columns[target_object.id.val] = header_resolver\
+                .create_columns()
             log.debug('Columns: %r' % self.columns)
             if len(self.columns) > MAX_COLUMN_COUNT:
                 log.warn("Column count exceeds max column count")
@@ -1003,8 +1005,10 @@ class ParsingContext(object):
 
         self.filter_functions = dict()
         for target_id in self.target_ids:
-            self.filter_functions[target_id] = self.parsing_util_factory.get_filter_function(
-                filter_header_index, self.value_resolver.wrapper.target_names[target_id])
+            self.filter_functions[target_id] = self.parsing_util_factory\
+                                                   .get_filter_function(
+                filter_header_index,
+                self.value_resolver.wrapper.target_names[target_id])
 
         tables = self.create_tables()
         self.populate_from_reader(reader, self.filter_functions, tables, 1000)
@@ -1024,7 +1028,8 @@ class ParsingContext(object):
                 raise MetadataError(
                     "Unable to create table: %s" % DEFAULT_TABLE_NAME)
             original_file = table.getOriginalFile()
-            log.info('Created new table OriginalFile: %d for %d' % (original_file.id.val, target_id))
+            log.info('Created new table OriginalFile: %d for %d' %
+                     (original_file.id.val, target_id))
             table.initialize(self.columns[target_id])
             tables[target_id] = table
         return tables
@@ -1067,8 +1072,8 @@ class ParsingContext(object):
                         elif column.name.lower() == "plate":
                             column.values.append(value)
                     except TypeError:
-                        log.error('Original value "%s" now "%s" of bad type!' % (
-                            original_value, value))
+                        log.error('Original value "%s" now "%s" of '
+                                  'bad type!' % (original_value, value))
                         raise
                 self.post_process(target_id)
                 for column in columns:

--- a/src/populate_metadata.py
+++ b/src/populate_metadata.py
@@ -1029,7 +1029,7 @@ class ParsingContext(object):
             self.columns[target_object.id.val] = header_resolver\
                 .create_columns()
             log.debug('Columns: %r' % self.columns)
-            if len(self.columns) > MAX_COLUMN_COUNT:
+            if len(self.columns[target_object.id.val]) > MAX_COLUMN_COUNT:
                 log.warn("Column count exceeds max column count")
 
         self.preprocess_data(reader)

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -213,7 +213,7 @@ class Screen2Plates(Fixture):
     def get_target(self):
         if not self.screen:
             self.screen = self.create_screen(self.row_count, self.col_count)
-        return self.screen
+        return [self.screen]
 
     def get_annotations(self):
         query = """select s from Screen s
@@ -249,7 +249,7 @@ class Plate2Wells(Fixture):
     def get_target(self):
         if not self.plate:
             self.plate = self.create_plate(self.row_count, self.col_count)
-        return self.plate
+        return [self.plate]
 
     def get_annotations(self):
         query = """select p from Plate p
@@ -662,7 +662,7 @@ class Dataset2Images(Fixture):
         if not self.dataset:
             self.dataset = self.create_dataset(self.names)
             self.images = self.get_dataset_images()
-        return self.dataset
+        return [self.dataset]
 
     def get_dataset_images(self):
         if not self.dataset:
@@ -805,7 +805,7 @@ class Project2Datasets(Fixture):
         if not self.project:
             self.project = self.create_project("P123")
             self.images = self.get_project_images()
-        return self.project
+        return [self.project]
 
     def get_project_images(self):
         if not self.project:
@@ -1234,7 +1234,7 @@ class TestPopulateMetadataConfigFiles(TestPopulateMetadataHelperPerMethod):
     def _init_fixture_attach_cfg(self):
         fixture = Plate2Wells()
         fixture.init(self)
-        target = fixture.get_target()
+        target = fixture.get_target()[0]
         ofile = self.client.upload(fixture.get_cfg()).proxy()
         link = PlateAnnotationLinkI()
         link.parent = target.proxy()
@@ -1420,7 +1420,7 @@ class ROICSV(Fixture):
         if not self.plate:
             self.plate = self.create_plate(
                 self.row_count, self.col_count)
-        return self.plate
+        return [self.plate]
 
 
 @pythonminver
@@ -1434,7 +1434,7 @@ class TestPopulateRois(ITest):
 
         fixture = ROICSV()
         fixture.init(self)
-        plate = fixture.get_target()
+        plate = fixture.get_target()[0]
 
         # As opposed to the ParsingContext, here we are expected
         # to link the file ourselves


### PR DESCRIPTION
Follow up to  #15 .

With this PR one could specifiy multiple targets (e. g. `./omero metadata populate --file test.csv Dataset:1,2,3,4,5`). For each target a bulk_annotations table will be created and attached, containing only the information specific to this target. This only requires one round of parsing through the provided csv file (well, I think it's actually two rounds, a pre-processing step and then the actual parsing).

/cc @sbesson 
