### PR TITLE
Adjust integration test for change in global metadata.

### DIFF
--- a/test/integration/clitest/test_metadata.py
+++ b/test/integration/clitest/test_metadata.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2013-2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2013-2019 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -120,7 +120,7 @@ class TestMetadata(MetadataTestBase):
         origmd = self.md.get_original()
         assert len(origmd) == 3
         assert origmd[0] is None
-        assert len(origmd[1]) == 2
+        assert len(origmd[1]) == 1
         assert len(origmd[2]) == 0
 
     @pytest.mark.parametrize('annotations', [False, True])


### PR DESCRIPTION
Adjusts integration test to no longer expect `OriginalMetadataRequest` to return `header: GlobalMetadata` since https://github.com/openmicroscopy/bioformats/pull/3332. Corresponds with https://github.com/openmicroscopy/openmicroscopy/pull/6015.