### PR TITLE
Strip all csv values of whitespace

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -911,7 +911,7 @@ class ParsingContext(object):
         return widths
 
     def preprocess_from_handle(self, data):
-        reader = csv.reader(data, delimiter=',')
+        reader = csv.reader(data, delimiter=',', skipinitialspace=True)
         first_row = reader.next()
         header_row = first_row
         first_row_is_types = HeaderResolver.is_row_column_types(first_row)
@@ -938,7 +938,7 @@ class ParsingContext(object):
         self.preprocess_data(reader)
 
     def parse_from_handle_stream(self, data):
-        reader = csv.reader(data, delimiter=',')
+        reader = csv.reader(data, delimiter=',', skipinitialspace=True)
         first_row = reader.next()
         header_row = first_row
         first_row_is_types = HeaderResolver.is_row_column_types(first_row)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -912,13 +912,13 @@ class ParsingContext(object):
 
     def preprocess_from_handle(self, data):
         reader = csv.reader(data, delimiter=',')
-        first_row = [h.strip() for h in reader.next()]
+        first_row = reader.next()
         header_row = first_row
         first_row_is_types = HeaderResolver.is_row_column_types(first_row)
         header_index = 0
         if first_row_is_types:
             header_index = 1
-            header_row = [h.strip() for h in reader.next()]
+            header_row = reader.next()
         log.debug('Header: %r' % header_row)
         for h in first_row:
             if not h:
@@ -939,11 +939,11 @@ class ParsingContext(object):
 
     def parse_from_handle_stream(self, data):
         reader = csv.reader(data, delimiter=',')
-        first_row = [h.strip() for h in reader.next()]
+        first_row = reader.next()
         header_row = first_row
         first_row_is_types = HeaderResolver.is_row_column_types(first_row)
         if first_row_is_types:
-            header_row = [h.strip() for h in reader.next()]
+            header_row = reader.next()
 
         filter_header_index = -1
         for i, name in enumerate(header_row):
@@ -1005,7 +1005,7 @@ class ParsingContext(object):
             if column.name not in ADDED_COLUMN_NAMES:
                 column_count += 1
         for i, row in enumerate(reader):
-            row = [(self.columns[i], value.strip()) for i, value in enumerate(row)]
+            row = [(self.columns[i], value) for i, value in enumerate(row)]
             for column, original_value in row:
                 log.debug('Original value %s, %s',
                           original_value, column.name)
@@ -1072,7 +1072,6 @@ class ParsingContext(object):
         """
         row_count = 0
         for (r, row) in enumerate(reader):
-            row = [d.strip() for d in row]
             log.debug('Row %d', r)
             if filter_function(row):
                 self.populate_row(row)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -912,13 +912,13 @@ class ParsingContext(object):
 
     def preprocess_from_handle(self, data):
         reader = csv.reader(data, delimiter=',')
-        first_row = reader.next()
+        first_row = [h.strip() for h in reader.next()]
         header_row = first_row
         first_row_is_types = HeaderResolver.is_row_column_types(first_row)
         header_index = 0
         if first_row_is_types:
             header_index = 1
-            header_row = reader.next()
+            header_row = [h.strip() for h in reader.next()]
         log.debug('Header: %r' % header_row)
         for h in first_row:
             if not h:
@@ -939,11 +939,11 @@ class ParsingContext(object):
 
     def parse_from_handle_stream(self, data):
         reader = csv.reader(data, delimiter=',')
-        first_row = reader.next()
+        first_row = [h.strip() for h in reader.next()]
         header_row = first_row
         first_row_is_types = HeaderResolver.is_row_column_types(first_row)
         if first_row_is_types:
-            header_row = reader.next()
+            header_row = [h.strip() for h in reader.next()]
 
         filter_header_index = -1
         for i, name in enumerate(header_row):
@@ -1005,7 +1005,7 @@ class ParsingContext(object):
             if column.name not in ADDED_COLUMN_NAMES:
                 column_count += 1
         for i, row in enumerate(reader):
-            row = [(self.columns[i], value) for i, value in enumerate(row)]
+            row = [(self.columns[i], value.strip()) for i, value in enumerate(row)]
             for column, original_value in row:
                 log.debug('Original value %s, %s',
                           original_value, column.name)
@@ -1072,6 +1072,7 @@ class ParsingContext(object):
         """
         row_count = 0
         for (r, row) in enumerate(reader):
+            row = [d.strip() for d in row]
             log.debug('Row %d', r)
             if filter_function(row):
                 self.populate_row(row)


### PR DESCRIPTION
See https://github.com/ome/omero-metadata/issues/24

This should allow ```csv``` files to contain values with whitespace.
All values read from a csv file are stripped of whitespace with ```v.strip()```.

To test:
 - Edit a csv file known to work with the populate metadata script, adding whitespace around various values in the columns or rows of the table.
 - The csv should still work as before.