### PR TITLE
Usage instructions in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,106 @@ version 5.4.x of OMERO.py. When using the CLI metadata plugin, the
 `OMERO_DEV_PLUGINS` environment variable should not be set to prevent
 conflicts when importing the Python module.
 
+Usage
+=====
+
+The plugin is called from the command-line using the `omero` command::
+
+    $ bin/omero metadata &lt;subcommand&gt;
+
+Help for each command can be shown using the ``-h`` flag.
+Objects can be specified as arguments in the format ```Class:ID```, such
+as ```Project:123```.
+
+Available subcommands are:
+
+ - ``allanns``: Provide a list of all annotations linked to the given object
+ - ``bulkanns``: Provide a list of the NSBULKANNOTATION tables linked to the given object
+ - ``mapanns``: Provide a list of all MapAnnotations linked to the given object
+ - ``measures``: Provide a list of the NSMEASUREMENT tables linked to the given object
+ - ``original``: Print the original metadata in ini format
+ - ``pixelsize``: Set physical pixel size
+ - ``populate``: Add metadata (bulk-annotations) to an object (see below)
+ - ``populateroi``: Add ROIs to an object
+ - ``rois``: Manage ROIs
+ - ``summary``: Provide a general summary of available metadata
+ - ``testtables``: Tests whether tables can be created and initialized
+
+populate
+--------
+
+This command creates an ``OMERO.table`` (bulk annotation) from a ``CSV`` file and links 
+the table as a ``File Annotation`` to a parent container such as Screen, Plate, Project
+or Dataset. It also attempts to convert Image or Well names from the ``CSV`` into
+Image or Well IDs in the ``OMERO.table``.
+
+The ```CSV``` file can be provided as local file with ``--file path/to/file.csv``
+or as an OriginalFile in OMERO with ``--fileid 123``.
+
+If you wish to ensure that ``number`` columns are created for numerical data, this will
+allow you to make numerical queries on the table.
+Column Types are::
+
+    'plate': PlateColumn, 'well': WellColumn, 'image': ImageColumn,
+    'dataset': DatasetColumn, 'roi': RoiColumn, 'd': DoubleColumn, 'l': LongColumn,
+    's': StringColumn, 'b': BoolColumn
+
+These can be specified in the first row of a ``CSV`` with a ``# header`` tag.
+
+NB: Column names should not contain whitespace if you want to be able to query
+by these columns.
+
+Examples:
+
+To add a table to a Screen, the ``CSV`` file needs to specify ``Plate Name`` and ``Well``::
+
+    $ bin/omero metadata populate Plate:1 path/to/screen.csv
+
+screen.csv::
+
+    # header well,plate,s,d,l,d
+    Well,Plate,Drug,Concentration,Cell_Count,Percent_Mitotic
+    A1,plate01,DMSO,10.1,10,25.4
+    A2,plate01,DMSO,0.1,1000,2.54
+    A3,plate01,DMSO,5.5,550,4
+    B1,plate01,Monastrol,12.3,50,44.43
+    B2,plate01,Drug3,1.1,1,15.4
+    B3,plate01,Water,20.1,44,12.3
+
+This will create an OMERO.table linked to the Screen like this::
+
+    Well	Plate	Drug	Concentration	Cell_Count	Percent_Mitotic	Well Name	Plate Name
+    9154	3855	DMSO	10.1	        10	        25.4	        a1	        plate01
+    9155	3855	DMSO	0.1	            1000	    2.54	        a2	        plate01
+    9156	3855	DMSO	5.5	            550	        4.0	            a3	        plate01
+    9157	3855	Monastrol	12.3	    50	        44.43	        b1	        plate01
+    9158	3855	Drug3	1.1	            1	        15.4	        b2	        plate01
+    9159	3855	Water	20.1	        44	        12.3	        b3	        plate01
+
+If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
+
+To add a table to a Project, the ``CSV`` file needs to specify ``Dataset``
+and ``Image``.
+
+For example::
+
+    # header s,s,d,l,s
+    Image Name,Dataset Name,Bounding_Box,Channel_Index,Channel_Name
+    img-01.png,dataset01,0.0469,1,DAPI
+    img-02.png,dataset01,0.142,2,GFP
+    img-03.png,dataset01,0.093,3,TRITC
+    img-04.png,dataset01,0.429,4,Cy5
+
+This will create an OMERO.table linked to the Project like this::
+
+    Image Name	Dataset Name	Bounding_Box	Channel_Index	Channel_Name	Image
+    img-01.png	dataset01	    0.0469	        1	            DAPI	        36638
+    img-02.png	dataset01	    0.142	        2	            GFP	            36639
+    img-03.png	dataset01	    0.093	        3	            TRITC	        36640
+    img-04.png	dataset01	    0.429	        4	            Cy5	            36641
+
+If the target is a Dataset instead of a Project, the ``Dataset Name`` column is not needed.
+
 License
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -152,4 +152,4 @@ licensed under the terms of the GNU General Public License (GPL) v2 or later.
 Copyright
 ---------
 
-2018, The Open Microscopy Environment
+2018-2019, The Open Microscopy Environment

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Usage
 
 The plugin is called from the command-line using the `omero` command::
 
-    $ bin/omero metadata &lt;subcommand&gt;
+    $ bin/omero metadata <subcommand>
 
 Help for each command can be shown using the ``-h`` flag.
 Objects can be specified as arguments in the format ```Class:ID```, such
@@ -45,17 +45,17 @@ as ```Project:123```.
 
 Available subcommands are:
 
- - ``allanns``: Provide a list of all annotations linked to the given object
- - ``bulkanns``: Provide a list of the NSBULKANNOTATION tables linked to the given object
- - ``mapanns``: Provide a list of all MapAnnotations linked to the given object
- - ``measures``: Provide a list of the NSMEASUREMENT tables linked to the given object
- - ``original``: Print the original metadata in ini format
- - ``pixelsize``: Set physical pixel size
- - ``populate``: Add metadata (bulk-annotations) to an object (see below)
- - ``populateroi``: Add ROIs to an object
- - ``rois``: Manage ROIs
- - ``summary``: Provide a general summary of available metadata
- - ``testtables``: Tests whether tables can be created and initialized
+- ``allanns``: Provide a list of all annotations linked to the given object
+- ``bulkanns``: Provide a list of the NSBULKANNOTATION tables linked to the given object
+- ``mapanns``: Provide a list of all MapAnnotations linked to the given object
+- ``measures``: Provide a list of the NSMEASUREMENT tables linked to the given object
+- ``original``: Print the original metadata in ini format
+- ``pixelsize``: Set physical pixel size
+- ``populate``: Add metadata (bulk-annotations) to an object (see below)
+- ``populateroi``: Add ROIs to an object
+- ``rois``: Manage ROIs
+- ``summary``: Provide a general summary of available metadata
+- ``testtables``: Tests whether tables can be created and initialized
 
 populate
 --------
@@ -65,7 +65,7 @@ the table as a ``File Annotation`` to a parent container such as Screen, Plate, 
 or Dataset. It also attempts to convert Image or Well names from the ``CSV`` into
 Image or Well IDs in the ``OMERO.table``.
 
-The ```CSV``` file can be provided as local file with ``--file path/to/file.csv``
+The ``CSV`` file can be provided as local file with ``--file path/to/file.csv``
 or as an OriginalFile in OMERO with ``--fileid 123``.
 
 If you wish to ensure that ``number`` columns are created for numerical data, this will
@@ -76,14 +76,14 @@ Column Types are::
     'dataset': DatasetColumn, 'roi': RoiColumn, 'd': DoubleColumn, 'l': LongColumn,
     's': StringColumn, 'b': BoolColumn
 
-These can be specified in the first row of a ``CSV`` with a ``# header`` tag.
+These can be specified in the first row of a ``CSV`` with a ``# header`` tag (see examples below).
 
 NB: Column names should not contain whitespace if you want to be able to query
 by these columns.
 
 Examples:
 
-To add a table to a Screen, the ``CSV`` file needs to specify ``Plate Name`` and ``Well``::
+To add a table to a Screen, the ``CSV`` file needs to specify ``Plate`` name and ``Well``::
 
     $ bin/omero metadata populate Plate:1 path/to/screen.csv
 

--- a/README.rst
+++ b/README.rst
@@ -98,15 +98,16 @@ screen.csv::
     B2,plate01,Drug3,1.1,1,15.4
     B3,plate01,Water,20.1,44,12.3
 
-This will create an OMERO.table linked to the Screen like this::
+This will create an OMERO.table linked to the Screen like this:
 
-    Well	Plate	Drug	Concentration	Cell_Count	Percent_Mitotic	Well Name	Plate Name
-    9154	3855	DMSO	10.1	        10	        25.4	        a1	        plate01
-    9155	3855	DMSO	0.1	            1000	    2.54	        a2	        plate01
-    9156	3855	DMSO	5.5	            550	        4.0	            a3	        plate01
-    9157	3855	Monastrol	12.3	    50	        44.43	        b1	        plate01
-    9158	3855	Drug3	1.1	            1	        15.4	        b2	        plate01
-    9159	3855	Water	20.1	        44	        12.3	        b3	        plate01
+Well | Plate  | Drug | Concentration  | Cell_Count | Percent_Mitotic | Well Name | Plate Name
+---- | ------ | -----|--------------- | ---------- | -------------- | ---------- | ----------
+9154 | 3855   | DMSO | 10.1           |         10 | 25.4           |         a1 |  plate01
+9155 | 3855   | DMSO | 0.1            |       1000 | 2.54           |         a2 |  plate01
+9156 | 3855   | DMSO | 5.5            |        550 | 4.0            |         a3 |  plate01
+9157 | 3855   | Monastrol |  12.3     |         50 | 44.43          |         b1 |  plate01
+9158 | 3855   | Drug3 |           1.1 |          1 | 15.4           |         b2 |  plate01
+9159 | 3855   | Water | 20.1          |         44 | 12.3           |         b3 |  plate01
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@
 OMERO metadata plugin
 =====================
 
-Plugin for use in the OMERO CLI.
+Plugin for use in the OMERO CLI. Provides tools for bulk
+management of annotations on objects in OMERO.
 
 Requirements
 ============
@@ -43,6 +44,9 @@ Help for each command can be shown using the ``-h`` flag.
 Objects can be specified as arguments in the format ``Class:ID``, such
 as ``Project:123``.
 
+Bulk-annotations are HDF-based tables with the NSBULKANNOTATION
+namespace, sometimes referred to as OMERO.tables.
+
 Available subcommands are:
 
 - ``allanns``: Provide a list of all annotations linked to the given object
@@ -52,7 +56,6 @@ Available subcommands are:
 - ``original``: Print the original metadata in ini format
 - ``pixelsize``: Set physical pixel size
 - ``populate``: Add metadata (bulk-annotations) to an object (see below)
-- ``populateroi``: Add ROIs to an object
 - ``rois``: Manage ROIs
 - ``summary``: Provide a general summary of available metadata
 - ``testtables``: Tests whether tables can be created and initialized
@@ -81,7 +84,7 @@ Column Types are:
 These can be specified in the first row of a ``CSV`` with a ``# header`` tag (see examples below).
 The ``# header`` row is optional. Default column type is ``String``.
 
-NB: Column names should not contain whitespace if you want to be able to query
+NB: Column names should not contain spaces if you want to be able to query
 by these columns.
 
 Examples:
@@ -94,7 +97,7 @@ and ``Image Name``::
 project.csv::
 
     # header s,s,d,l,s
-    Image Name,Dataset Name,Bounding_Box,Channel_Index,Channel_Name
+    Image Name,Dataset Name,ROI_Area,Channel_Index,Channel_Name
     img-01.png,dataset01,0.0469,1,DAPI
     img-02.png,dataset01,0.142,2,GFP
     img-03.png,dataset01,0.093,3,TRITC
@@ -102,14 +105,14 @@ project.csv::
 
 This will create an OMERO.table linked to the Project like this:
 
-========== ============ ============ ============= ============ =====
-Image Name Dataset Name Bounding_Box Channel_Index Channel_Name Image
-========== ============ ============ ============= ============ =====
-img-01.png dataset01    0.0469       1             DAPI         36638
-img-02.png dataset01    0.142        2             GFP          36639
-img-03.png dataset01    0.093        3             TRITC        36640
-img-04.png dataset01    0.429        4             Cy5          36641
-========== ============ ============ ============= ============ =====
+========== ============ ======== ============= ============ =====
+Image Name Dataset Name ROI_Area Channel_Index Channel_Name Image
+========== ============ ======== ============= ============ =====
+img-01.png dataset01    0.0469   1             DAPI         36638
+img-02.png dataset01    0.142    2             GFP          36639
+img-03.png dataset01    0.093    3             TRITC        36640
+img-04.png dataset01    0.429    4             Cy5          36641
+========== ============ ======== ============= ============ =====
 
 If the target is a Dataset instead of a Project, the ``Dataset Name`` column is not needed.
 

--- a/README.rst
+++ b/README.rst
@@ -94,23 +94,18 @@ screen.csv::
     A1,plate01,DMSO,10.1,10,25.4
     A2,plate01,DMSO,0.1,1000,2.54
     A3,plate01,DMSO,5.5,550,4
-    B1,plate01,Monastrol,12.3,50,44.43
-    B2,plate01,Drug3,1.1,1,15.4
-    B3,plate01,Water,20.1,44,12.3
+    B1,plate01,DrugX,12.3,50,44.43
 
 This will create an OMERO.table linked to the Screen like this:
 
-===== ====== ====== ==============  =========== ===============  =========  ===========
-Well  Plate   Drug  Concentration   Cell_Count  Percent_Mitotic  Well Name  Plate Name 
-===== ====== ====== ==============  =========== ===============  =========  ===========
- 9154  3855    DMSO  10.1                    10  25.4                   a1   plate01
- 9155  3855    DMSO  0.1                   1000  2.54                   a2   plate01
- 9156  3855    DMSO  5.5                    550  4.0                    a3   plate01
- 9157  3855    Monastrol   12.3              50  44.43                  b1   plate01
- 9158  3855    Drug3       1.1                1  15.4                   b2   plate01
- 9159  3855    Water  20.1                   44  12.3                   b3   plate01
-===== ====== ====== ==============  =========== ===============  =========  ===========
-
+===== ====== ====== ============== =========== ================ =========== ===========
+Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plate Name
+===== ====== ====== ============== =========== ================ =========== ===========
+9154  3855   DMSO   10.1           10          25.4             a1          plate01
+9155  3855   DMSO   0.1            1000        2.54             a2          plate01
+9156  3855   DMSO   5.5            550         4.0              a3          plate01
+9157  3855   DrugX  12.3           50          44.43            b1          plate01
+===== ====== ====== ============== =========== ================ =========== ===========
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 
@@ -126,13 +121,16 @@ For example::
     img-03.png,dataset01,0.093,3,TRITC
     img-04.png,dataset01,0.429,4,Cy5
 
-This will create an OMERO.table linked to the Project like this::
+This will create an OMERO.table linked to the Project like this:
 
-    Image Name	Dataset Name	Bounding_Box	Channel_Index	Channel_Name	Image
-    img-01.png	dataset01	    0.0469	        1	            DAPI	        36638
-    img-02.png	dataset01	    0.142	        2	            GFP	            36639
-    img-03.png	dataset01	    0.093	        3	            TRITC	        36640
-    img-04.png	dataset01	    0.429	        4	            Cy5	            36641
+========== ============ ============ ============= ============ =====
+Image Name Dataset Name Bounding_Box Channel_Index Channel_Name Image
+========== ============ ============ ============= ============ =====
+img-01.png dataset01    0.0469       1             DAPI         36638
+img-02.png dataset01    0.142        2             GFP          36639
+img-03.png dataset01    0.093        3             TRITC        36640
+img-04.png dataset01    0.429        4             Cy5          36641
+========== ============ ============ ============= ============ =====
 
 If the target is a Dataset instead of a Project, the ``Dataset Name`` column is not needed.
 

--- a/README.rst
+++ b/README.rst
@@ -100,21 +100,16 @@ screen.csv::
 
 This will create an OMERO.table linked to the Screen like this:
 
-
-| Well | Plate  | Drug | Concentration  | Cell_Count | Percent_Mitotic | Well Name | Plate Name |
-| ---- | ------ | ---- | -------------- | ---------- | -------------- | ---------- | ---------- |
-| 9154 | 3855   | DMSO | 10.1           |         10 | 25.4           |         a1 |  plate01 |
-| 9155 | 3855   | DMSO | 0.1            |       1000 | 2.54           |         a2 |  plate01 |
-| 9156 | 3855   | DMSO | 5.5            |        550 | 4.0            |         a3 |  plate01 |
-| 9157 | 3855   | Monastrol |  12.3     |         50 | 44.43          |         b1 |  plate01 |
-| 9158 | 3855   | Drug3 |           1.1 |          1 | 15.4           |         b2 |  plate01 |
-| 9159 | 3855   | Water | 20.1          |         44 | 12.3           |         b3 |  plate01 |
-
-
-| First Header  | Second Header |
-| ------------- | ------------- |
-| Content Cell  | Content Cell  |
-| Content Cell  | Content Cell  |
+===== ====== ====== ==============  =========== ===============  =========  ===========
+Well  Plate   Drug  Concentration   Cell_Count  Percent_Mitotic  Well Name  Plate Name 
+===== ====== ====== ==============  =========== ===============  =========  ===========
+ 9154  3855    DMSO  10.1                    10  25.4                   a1   plate01
+ 9155  3855    DMSO  0.1                   1000  2.54                   a2   plate01
+ 9156  3855    DMSO  5.5                    550  4.0                    a3   plate01
+ 9157  3855    Monastrol   12.3              50  44.43                  b1   plate01
+ 9158  3855    Drug3       1.1                1  15.4                   b2   plate01
+ 9159  3855    Water  20.1                   44  12.3                   b3   plate01
+===== ====== ====== ==============  =========== ===============  =========  ===========
 
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.

--- a/README.rst
+++ b/README.rst
@@ -101,14 +101,20 @@ screen.csv::
 This will create an OMERO.table linked to the Screen like this:
 
 
-| Well | Plate  | Drug | Concentration  | Cell_Count | Percent_Mitotic | Well Name | Plate Name|
-| ---- | ------ | -----|--------------- | ---------- | -------------- | ---------- | ---------- |
+| Well | Plate  | Drug | Concentration  | Cell_Count | Percent_Mitotic | Well Name | Plate Name |
+| ---- | ------ | ---- | -------------- | ---------- | -------------- | ---------- | ---------- |
 | 9154 | 3855   | DMSO | 10.1           |         10 | 25.4           |         a1 |  plate01 |
 | 9155 | 3855   | DMSO | 0.1            |       1000 | 2.54           |         a2 |  plate01 |
 | 9156 | 3855   | DMSO | 5.5            |        550 | 4.0            |         a3 |  plate01 |
 | 9157 | 3855   | Monastrol |  12.3     |         50 | 44.43          |         b1 |  plate01 |
 | 9158 | 3855   | Drug3 |           1.1 |          1 | 15.4           |         b2 |  plate01 |
 | 9159 | 3855   | Water | 20.1          |         44 | 12.3           |         b3 |  plate01 |
+
+
+| First Header  | Second Header |
+| ------------- | ------------- |
+| Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  |
 
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.

--- a/README.rst
+++ b/README.rst
@@ -100,14 +100,16 @@ screen.csv::
 
 This will create an OMERO.table linked to the Screen like this:
 
-Well | Plate  | Drug | Concentration  | Cell_Count | Percent_Mitotic | Well Name | Plate Name
----- | ------ | -----|--------------- | ---------- | -------------- | ---------- | ----------
-9154 | 3855   | DMSO | 10.1           |         10 | 25.4           |         a1 |  plate01
-9155 | 3855   | DMSO | 0.1            |       1000 | 2.54           |         a2 |  plate01
-9156 | 3855   | DMSO | 5.5            |        550 | 4.0            |         a3 |  plate01
-9157 | 3855   | Monastrol |  12.3     |         50 | 44.43          |         b1 |  plate01
-9158 | 3855   | Drug3 |           1.1 |          1 | 15.4           |         b2 |  plate01
-9159 | 3855   | Water | 20.1          |         44 | 12.3           |         b3 |  plate01
+
+| Well | Plate  | Drug | Concentration  | Cell_Count | Percent_Mitotic | Well Name | Plate Name|
+| ---- | ------ | -----|--------------- | ---------- | -------------- | ---------- | ---------- |
+| 9154 | 3855   | DMSO | 10.1           |         10 | 25.4           |         a1 |  plate01 |
+| 9155 | 3855   | DMSO | 0.1            |       1000 | 2.54           |         a2 |  plate01 |
+| 9156 | 3855   | DMSO | 5.5            |        550 | 4.0            |         a3 |  plate01 |
+| 9157 | 3855   | Monastrol |  12.3     |         50 | 44.43          |         b1 |  plate01 |
+| 9158 | 3855   | Drug3 |           1.1 |          1 | 15.4           |         b2 |  plate01 |
+| 9159 | 3855   | Water | 20.1          |         44 | 12.3           |         b3 |  plate01 |
+
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 

--- a/README.rst
+++ b/README.rst
@@ -70,49 +70,28 @@ or as an OriginalFile in OMERO with ``--fileid 123``.
 
 If you wish to ensure that ``number`` columns are created for numerical data, this will
 allow you to make numerical queries on the table.
-Column Types are::
+Column Types are:
 
-    'plate': PlateColumn, 'well': WellColumn, 'image': ImageColumn,
-    'dataset': DatasetColumn, 'roi': RoiColumn, 'd': DoubleColumn, 'l': LongColumn,
-    's': StringColumn, 'b': BoolColumn
+- 'plate', 'well', 'image', 'dataset', 'roi' to specify objects
+- 'd': DoubleColumn, for floating point numbers
+- 'l': LongColumn, for integer numbers
+- 's': StringColumn, for text
+- 'b': BoolColumn, for true/false
 
 These can be specified in the first row of a ``CSV`` with a ``# header`` tag (see examples below).
+The ``# header`` row is optional. Default column type is ``String``.
 
 NB: Column names should not contain whitespace if you want to be able to query
 by these columns.
 
 Examples:
 
-To add a table to a Screen, the ``CSV`` file needs to specify ``Plate`` name and ``Well``::
+To add a table to a Project, the ``CSV`` file needs to specify ``Dataset Name``
+and ``Image Name``:
 
-    $ bin/omero metadata populate Plate:1 path/to/screen.csv
+    $ bin/omero metadata populate Project:1 path/to/project.csv
 
-screen.csv::
-
-    # header well,plate,s,d,l,d
-    Well,Plate,Drug,Concentration,Cell_Count,Percent_Mitotic
-    A1,plate01,DMSO,10.1,10,25.4
-    A2,plate01,DMSO,0.1,1000,2.54
-    A3,plate01,DMSO,5.5,550,4
-    B1,plate01,DrugX,12.3,50,44.43
-
-This will create an OMERO.table linked to the Screen like this:
-
-===== ====== ====== ============== =========== ================ =========== ===========
-Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plate Name
-===== ====== ====== ============== =========== ================ =========== ===========
-9154  3855   DMSO   10.1           10          25.4             a1          plate01
-9155  3855   DMSO   0.1            1000        2.54             a2          plate01
-9156  3855   DMSO   5.5            550         4.0              a3          plate01
-9157  3855   DrugX  12.3           50          44.43            b1          plate01
-===== ====== ====== ============== =========== ================ =========== ===========
-
-If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
-
-To add a table to a Project, the ``CSV`` file needs to specify ``Dataset``
-and ``Image``.
-
-For example::
+project.csv::
 
     # header s,s,d,l,s
     Image Name,Dataset Name,Bounding_Box,Channel_Index,Channel_Name
@@ -133,6 +112,33 @@ img-04.png dataset01    0.429        4             Cy5          36641
 ========== ============ ============ ============= ============ =====
 
 If the target is a Dataset instead of a Project, the ``Dataset Name`` column is not needed.
+
+To add a table to a Screen, the ``CSV`` file needs to specify ``Plate`` name and ``Well``.
+If a ```# header``` is specified, column types must be ``well`` and ``plate``.
+
+screen.csv::
+
+    # header well,plate,s,d,l,d
+    Well,Plate,Drug,Concentration,Cell_Count,Percent_Mitotic
+    A1,plate01,DMSO,10.1,10,25.4
+    A2,plate01,DMSO,0.1,1000,2.54
+    A3,plate01,DMSO,5.5,550,4
+    B1,plate01,DrugX,12.3,50,44.43
+
+This will create an OMERO.table linked to the Screen, with the
+```Well Name``` and ```Plate Name``` columns added and the ```Well``` and
+```Plate``` columns used for IDs:
+
+===== ====== ====== ============== =========== ================ =========== ===========
+Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plate Name
+===== ====== ====== ============== =========== ================ =========== ===========
+9154  3855   DMSO   10.1           10          25.4             a1          plate01
+9155  3855   DMSO   0.1            1000        2.54             a2          plate01
+9156  3855   DMSO   5.5            550         4.0              a3          plate01
+9157  3855   DrugX  12.3           50          44.43            b1          plate01
+===== ====== ====== ============== =========== ================ =========== ===========
+
+If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ The plugin is called from the command-line using the `omero` command::
     $ bin/omero metadata <subcommand>
 
 Help for each command can be shown using the ``-h`` flag.
-Objects can be specified as arguments in the format ```Class:ID```, such
-as ```Project:123```.
+Objects can be specified as arguments in the format ``Class:ID``, such
+as ``Project:123``.
 
 Available subcommands are:
 
@@ -72,11 +72,11 @@ If you wish to ensure that ``number`` columns are created for numerical data, th
 allow you to make numerical queries on the table.
 Column Types are:
 
-- 'plate', 'well', 'image', 'dataset', 'roi' to specify objects
-- 'd': DoubleColumn, for floating point numbers
-- 'l': LongColumn, for integer numbers
-- 's': StringColumn, for text
-- 'b': BoolColumn, for true/false
+- ``d``: ``DoubleColumn``, for floating point numbers
+- ``l``: ``LongColumn``, for integer numbers
+- ``s``: ``StringColumn``, for text
+- ``b``: ``BoolColumn``, for true/false
+- ``plate``, ``well``, ``image``, ``dataset``, ``roi`` to specify objects
 
 These can be specified in the first row of a ``CSV`` with a ``# header`` tag (see examples below).
 The ``# header`` row is optional. Default column type is ``String``.
@@ -87,7 +87,7 @@ by these columns.
 Examples:
 
 To add a table to a Project, the ``CSV`` file needs to specify ``Dataset Name``
-and ``Image Name``:
+and ``Image Name``::
 
     $ bin/omero metadata populate Project:1 path/to/project.csv
 
@@ -114,7 +114,7 @@ img-04.png dataset01    0.429        4             Cy5          36641
 If the target is a Dataset instead of a Project, the ``Dataset Name`` column is not needed.
 
 To add a table to a Screen, the ``CSV`` file needs to specify ``Plate`` name and ``Well``.
-If a ```# header``` is specified, column types must be ``well`` and ``plate``.
+If a ``# header`` is specified, column types must be ``well`` and ``plate``.
 
 screen.csv::
 
@@ -126,8 +126,8 @@ screen.csv::
     B1,plate01,DrugX,12.3,50,44.43
 
 This will create an OMERO.table linked to the Screen, with the
-```Well Name``` and ```Plate Name``` columns added and the ```Well``` and
-```Plate``` columns used for IDs:
+``Well Name`` and ``Plate Name`` columns added and the ``Well`` and
+``Plate`` columns used for IDs:
 
 ===== ====== ====== ============== =========== ================ =========== ===========
 Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plate Name


### PR DESCRIPTION
Added usage instructions to the README, particularly for ```populate``` command.

See it staged at https://github.com/will-moore/omero-metadata/tree/usage_instructions_in_README