### PR TITLE
Do not warn on missing well/plate names when the target is non HCS

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1169,7 +1169,7 @@ class ParsingContext(object):
                     )
                 well_name_column.size = max(well_name_column.size, len(v))
                 well_name_column.values.append(v)
-            else:
+            elif (ScreenI is target_class or PlateI is target_class):
                 log.info('Missing well name column, skipping.')
 
             if image_name_column is not None and (
@@ -1242,7 +1242,7 @@ class ParsingContext(object):
                 v = self.value_resolver.get_plate_name_by_id(plate)
                 plate_name_column.size = max(plate_name_column.size, len(v))
                 plate_name_column.values.append(v)
-            else:
+            elif (ScreenI is target_class or PlateI is target_class):
                 log.info('Missing plate name column, skipping.')
 
 


### PR DESCRIPTION
This PR attempts to reduce the verbosity of the `populate` command when annotating a project or a dataset with a CSV file.

To test it, set up a dataset with a few images a CSV file as described in https://github.com/ome/omero-metadata#populate and run the populate command:

```
omero metadata populate --file=test.csv Project:<id>
```

Without this PR the command should log  info-level statements about missing plate and well columns. With this PR included, these irrelevant statements should be gone.