### PR TITLE
Improved support for annotations with Unicode characters

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -994,17 +994,15 @@ class ParsingContext(object):
 
     def parse(self):
         if self.file.endswith(".gz"):
-            data_for_preprocessing = gzip.open(self.file, "rt")
-            data = gzip.open(self.file, "rt")
+            with gzip.open(self.file, 'rt', encoding='utf-8') as f1:
+                self.preprocess_from_handle(f1)
+                with gzip.open(self.file, 'rt', encoding='utf-8') as f2:
+                    return self.parse_from_handle_stream(f2)
         else:
-            data_for_preprocessing = open(self.file, 'rt')
-            data = open(self.file, 'rt')
-
-        try:
-            self.preprocess_from_handle(data_for_preprocessing)
-            return self.parse_from_handle_stream(data)
-        finally:
-            data.close()
+            with open(self.file, 'rt', encoding='utf-8') as f1:
+                self.preprocess_from_handle(f1)
+                with open(self.file, 'rt', encoding='utf-8') as f2:
+                    return self.parse_from_handle_stream(f2)
 
     def preprocess_data(self, reader):
         # Get count of data columns - e.g. NOT Well Name

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1024,7 +1024,8 @@ class ParsingContext(object):
                 try:
                     log.debug("Value's class: %s" % value.__class__)
                     if isinstance(value, basestring):
-                        column.size = max(column.size, len(value))
+                        column.size = max(
+                            column.size, len(value.encode('utf-8')))
                     # The following are needed for
                     # getting post process column sizes
                     if column.__class__ is WellColumn:

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -994,14 +994,14 @@ class ParsingContext(object):
 
     def parse(self):
         if self.file.endswith(".gz"):
-            with gzip.open(self.file, 'rt', encoding='utf-8') as f1:
+            with gzip.open(self.file, 'rt', encoding='utf-8-sig') as f1:
                 self.preprocess_from_handle(f1)
-                with gzip.open(self.file, 'rt', encoding='utf-8') as f2:
+                with gzip.open(self.file, 'rt', encoding='utf-8-sig') as f2:
                     return self.parse_from_handle_stream(f2)
         else:
-            with open(self.file, 'rt', encoding='utf-8') as f1:
+            with open(self.file, 'rt', encoding='utf-8-sig') as f1:
                 self.preprocess_from_handle(f1)
-                with open(self.file, 'rt', encoding='utf-8') as f2:
+                with open(self.file, 'rt', encoding='utf-8-sig') as f2:
                     return self.parse_from_handle_stream(f2)
 
     def preprocess_data(self, reader):

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -774,6 +774,7 @@ class Unicode(Plate2Wells):
 
     def __init__(self):
         super(Unicode, self).__init__()
+        self.count = 5
         self.csv = self.create_csv(
             col_names="Well,Well Type,Concentration,Extra type",
             row_data=(u"A1,Control,0,მიკროსკოპის", u"A2,Treatment,10,პონი"),

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -102,11 +102,12 @@ class Fixture(object):
     def create_csv(
         self,
         col_names="Well,Well Type,Concentration",
-        row_data=("A1,Control,0", "A2,Treatment,10")
+        row_data=("A1,Control,0", "A2,Treatment,10"),
+        encoding=None,
     ):
 
         csv_filename = create_path("test", ".csv")
-        with open(csv_filename, 'w', encoding="utf-8") as csv_file:
+        with open(csv_filename, 'w', encoding=encoding) as csv_file:
             csv_file.write(col_names)
             csv_file.write("\n")
             csv_file.write("\n".join(row_data))
@@ -769,6 +770,16 @@ class GZIP(Dataset2Images):
         return gzip_filename
 
 
+class Unicode(Plate2Wells):
+
+    def __init__(self):
+        super(Unicode, self).__init__()
+        self.csv = self.create_csv(
+            col_names="Well,Well Type,Concentration,Extra type",
+            row_data=(u"A1,Control,0,მიკროსკოპის", u"A2,Treatment,10,პონი"),
+            encoding="utf-8")
+
+
 class Project2Datasets(Fixture):
 
     def __init__(self):
@@ -990,6 +1001,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         Dataset101Images(),
         Project2Datasets(),
         GZIP(),
+        Unicode(),
     )
     METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
 

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -781,6 +781,17 @@ class Unicode(Plate2Wells):
             encoding="utf-8")
 
 
+class UnicodeBOM(Plate2Wells):
+
+    def __init__(self):
+        super(UnicodeBOM, self).__init__()
+        self.count = 5
+        self.csv = self.create_csv(
+            col_names="Well,Well Type,Concentration,Extra type",
+            row_data=("A1,Control,0,მიკროსკოპის", "A2,Treatment,10,პონი"),
+            encoding="utf-8-sig")
+
+
 class Project2Datasets(Fixture):
 
     def __init__(self):
@@ -1003,6 +1014,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         Project2Datasets(),
         GZIP(),
         Unicode(),
+        UnicodeBOM(),
     )
     METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
 

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -70,9 +70,6 @@ from pytest import raises
 
 MAPR_NS_GENE = 'openmicroscopy.org/mapr/gene'
 
-pythonminver = mark.skipif(sys.version_info < (2, 7),
-                           reason="requires python2.7")
-
 
 def coord2offset(coord):
     """
@@ -110,13 +107,10 @@ class Fixture(object):
     ):
 
         csv_filename = create_path("test", ".csv")
-        csv_file = open(csv_filename, 'w')
-        try:
+        with open(csv_filename, 'w', encoding="utf-8") as csv_file:
             csv_file.write(col_names)
             csv_file.write("\n")
             csv_file.write("\n".join(row_data))
-        finally:
-            csv_file.close()
         return str(csv_filename)
 
     def create_project(self, name, datasets=("D001", "D002"),
@@ -854,7 +848,6 @@ class Project2Datasets(Fixture):
                 raise Exception("Unknown dataset: %s" % ds)
 
 
-@pythonminver
 class TestPopulateMetadataConfigLoad(ITest):
 
     def get_cfg_filepath(self):
@@ -879,7 +872,6 @@ class TestPopulateMetadataConfigLoad(ITest):
         self._assert_configs(default_cfg, column_cfgs, advanced_cfgs)
 
 
-@pythonminver
 class TestPopulateMetadataHelper(ITest):
 
     def _test_parsing_context(self, fixture, batch_size):
@@ -969,7 +961,6 @@ class TestPopulateMetadataHelper(ITest):
         assert len(fixture.get_all_map_annotations()) == 0
 
 
-@pythonminver
 class TestPopulateMetadataHelperPerMethod(TestPopulateMetadataHelper):
 
     # Some tests in this file check the counts of annotations in a fixed
@@ -990,7 +981,6 @@ class TestPopulateMetadataHelperPerMethod(TestPopulateMetadataHelper):
         super(TestPopulateMetadataHelperPerMethod, self).teardown_class()
 
 
-@pythonminver
 class TestPopulateMetadata(TestPopulateMetadataHelper):
 
     METADATA_FIXTURES = (
@@ -1068,7 +1058,6 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
             self._test_bulk_to_map_annotation_context(fixture_fail, 2)
 
 
-@pythonminver
 class TestPopulateMetadataDedup(TestPopulateMetadataHelperPerMethod):
 
     # Hard-code the number of expected map-annotations in these tests
@@ -1219,7 +1208,6 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelperPerMethod):
             fixture1, fixture2, ns)
 
 
-@pythonminver
 class TestPopulateMetadataConfigFiles(TestPopulateMetadataHelperPerMethod):
 
     def _init_fixture_attach_cfg(self):
@@ -1414,7 +1402,6 @@ class ROICSV(Fixture):
         return self.plate
 
 
-@pythonminver
 class TestPopulateRois(ITest):
 
     def test_populate_rois_plate(self):

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -35,7 +35,6 @@ import gzip
 import os.path
 import re
 import shutil
-import sys
 
 from omero.api import RoiOptions
 from omero.grid import ImageColumn


### PR DESCRIPTION
This is primarily driven by the `idr0067` IDR submission as the [annotation file](https://github.com/IDR/idr0067-king-yeastmeiosis/blob/master/experimentA/idr0067-experimentA-annotation.csv contained Unicode characters for the genetic background. This PR generally improves support and test coverage for the creation of OMERO.tables from UTF-8 CSV files containing Unicode characters with and without BOM.

c2fb0f1 ensure the string is encoded to `utf-8` before calculating the maximum length of the string column
667ba18 enforces that CSV files are always opened with UTF-8 encoding and also uses context manager to close both file handles
44f69e9 also includes support for CSV files with a leading BOM character (Fixes #39)

The Unicode support was manually tested in an IDR annotation workflow from a Python 3 client environment with a Python 2 server environment. Integration tests have been added for both case (74da887 and  917251f ) and should pass in Travis CI.

A minimal testing workflow would be to import `test&plateCols=2.fake` which should create a plate with two wells and run `populate metadata Plate:<id> --file <file>.csv` with the two different [annotations.zip](https://github.com/ome/omero-metadata/files/3947048/annotations.zip).