### PR TITLE
Define jinja2 as a requirement of omero-metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,8 @@ setup(
     install_requires=[
         'future',
         'omero-py>=5.6.dev4',
-        'PyYAML'
+        'PyYAML',
+        'jinja2'
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
The issue was encountered while working on the annotation of IDR dataset using a local Python 3 virtual environment. The `jinja2` requirement is mandatory for the context transforming bulk annotations into map annotations.

Note depending on the decisions on https://github.com/ome/omero-py/pull/114, this change might evolve into declaring a dependency on `omero-py` with some extra packages.