### PR TITLE
Add dependency on version 5.8 or more recent of omero-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,9 +124,7 @@ setup(
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
     install_requires=[
-        'future',
-        'omero-py>=5.6.0',
-        'PyYAML',
+        'omero-py>=5.8.0',
         'jinja2'
     ],
     python_requires='>=3',


### PR DESCRIPTION
The primary motivation is to get rid of the DeprecationWarning thrown on every invocation of `omero metadata populate --context bulkmap` fixed in ome/omero-py@dcde6b2.

Also remove PyYAML and future dependencies pulled transitively - but see https://github.com/ome/omero-cli-render/pull/45#issuecomment-698170137

See also https://github.com/ome/omero-cli-render/pull/45

Proposed tag: `0.5.1`