### PR TITLE
populate metadata at image-level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,32 @@ Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plat
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 
+If the target is an Image, a csv with ROI-level and object-level data can be used to create an ``OMERO.table`` (bulk annotation) as a ``File Annotation`` on an Image.
+
+image.csv::
+
+    # header l,l,d,l
+    roi,object,probability,area
+    501,1,0.8,250
+    502,1,0.9,500
+    503,1,0.2,25
+    503,2,0.8,400
+    503,3,0.5,200
+
+This will create an OMERO.table linked to the Image like this:
+
+=== ====== =========== ====
+roi object probability area
+=== ====== =========== ====
+501 1      0.8         250 
+502 1      0.9         500 
+503 1      0.2         25  
+503 2      0.8         400 
+503 3      0.5         200 
+=== ====== =========== ====
+
+Note that the ROI-level ``OMERO.table`` is not visible in the OMERO.web UI right-hand panel, but can be visualized by clicking the "eye" on the bulk annotation attachment on the Image.
+
 Developer install
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -142,11 +142,11 @@ Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plat
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 
-If the target is an Image, a csv with ROI-level and object-level data can be used to create an ``OMERO.table`` (bulk annotation) as a ``File Annotation`` on an Image.
+If the target is an Image, a csv with ROI-level and object-level data can be used to create an ``OMERO.table`` (bulk annotation) as a ``File Annotation`` on an Image. The ROI identifying column can be an ``roi`` type column containing ROI ID, and ``Roi Name`` column will be appended automatically (see example below). Alternatively, the input column can be ``Roi Name`` (with type ``s``), and an ``roi`` type column will be appended containing ROI IDs.
 
 image.csv::
 
-    # header l,l,d,l
+    # header roi,l,d,l
     roi,object,probability,area
     501,1,0.8,250
     502,1,0.9,500
@@ -156,15 +156,15 @@ image.csv::
 
 This will create an OMERO.table linked to the Image like this:
 
-=== ====== =========== ====
-roi object probability area
-=== ====== =========== ====
-501 1      0.8         250 
-502 1      0.9         500 
-503 1      0.2         25  
-503 2      0.8         400 
-503 3      0.5         200 
-=== ====== =========== ====
+=== ====== =========== ==== ========
+roi object probability area Roi Name
+=== ====== =========== ==== ========
+501 1      0.8         250  Sample1
+502 1      0.9         500  Sample2
+503 1      0.2         25   Sample3
+503 2      0.8         400  Sample3
+503 3      0.5         200  Sample3
+=== ====== =========== ==== ========
 
 Note that the ROI-level ``OMERO.table`` is not visible in the OMERO.web UI right-hand panel, but can be visualized by clicking the "eye" on the bulk annotation attachment on the Image.
 

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -150,7 +150,6 @@ class HeaderResolver(object):
     image_keys = {
         'roi': RoiColumn
     }
-    
     dataset_keys = {
         'image': ImageColumn,
         'image_name': StringColumn,
@@ -859,7 +858,6 @@ class ImageWrapper(ValueWrapper):
         super(ImageWrapper, self).__init__(value_resolver)
         self.rois_by_id = dict()
         self._load()
-    
     def resolve_roi(self, column, row, value):
         try:
             return self.rois_by_id[int(value)].id.val

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -858,6 +858,7 @@ class ImageWrapper(ValueWrapper):
         super(ImageWrapper, self).__init__(value_resolver)
         self.rois_by_id = dict()
         self._load()
+
     def resolve_roi(self, column, row, value):
         try:
             return self.rois_by_id[int(value)].id.val

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1410,7 +1410,7 @@ class ParsingContext(object):
                 assert i == len(roi_column.values)
                 roi_column.values.append(rid)
             else:
-                log.info('No ROI information resolution needed, skipping.')
+                log.debug('No ROI information resolution needed, skipping.')
 
 
 class _QueryContext(object):


### PR DESCRIPTION
Adds an ImageWrapper to populate an OMERO.table at the image-level with ROI-level data. This requires an `roi` column containing ROI ID. Multiple rows per-ROI ID are allowed (see object-level case below), but ROIs with appropriate IDs must exist in image.

Note that the Tables dropdown is not populated at the image-level, but a `bulk annotations` file is added to attachments.

This can also be used to populate object-level analytics to refer to objects in a label image/mask associated with an ROI, where objects are encoded by their pixel value in the label image. There is currently no checking of this `object` column (for example, to confirm that these objects exist in the label image associated with the corresponding ROI), and this column need not exist at all. Once the label mask workflow is solidified, these checks might be helpful to implement.

An example has been added to README.