### PR TITLE
Add deletebulkanns

### DIFF
--- a/test/integration/clitest/test_metadata.py
+++ b/test/integration/clitest/test_metadata.py
@@ -237,6 +237,18 @@ class TestMetadataControl(MetadataTestBase):
         else:
             assert "name:" not in o
 
+    def test_deletebulkanns(self, capfd):
+        tag, fab, fam, ma = self.create_annotations(self.image)
+
+        prx = "Image:%s" % self.imageid
+        self.args += ["deletebulkanns", prx]
+        o = self.invoke(capfd)
+        assert "FileAnnotation:" in o
+
+        # Should be empty since it's deleted
+        o = self.invoke(capfd)
+        assert len(o.strip()) == 0
+
     @pytest.mark.parametrize('report', [False, True])
     def test_measures(self, capfd, report):
         tag, fab, fam, ma = self.create_annotations(self.image)


### PR DESCRIPTION
New command to delete bulk annotation tables.

```
# Dry run
$ omero metadata deletebulkanns Project:1352 -n 
Using session for ...
FileAnnotation:27481235

# Delete
$ omero metadata deletebulkanns Project:1352 
Using session for ...
FileAnnotation:27481235

# Nothing left
$ omero metadata deletebulkanns Project:1352
Using session for ...
```