### PR TITLE
Nan values for bulk annotation tables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Examples:
 To add a table to a Project, the ``CSV`` file needs to specify ``Dataset Name``
 and ``Image Name``::
 
-    $ omero metadata populate Project:1 path/to/project.csv
+    $ omero metadata populate Project:1 --file path/to/project.csv
 
 project.csv::
 

--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,12 @@ Well  Plate  Drug   Concentration  Cell_Count  Percent_Mitotic  Well Name   Plat
 
 If the target is a Plate instead of a Screen, the ``Plate`` column is not needed.
 
-If the target is an Image, a csv with ROI-level and object-level data can be used to create an ``OMERO.table`` (bulk annotation) as a ``File Annotation`` on an Image. The ROI identifying column can be an ``roi`` type column containing ROI ID, and ``Roi Name`` column will be appended automatically (see example below). Alternatively, the input column can be ``Roi Name`` (with type ``s``), and an ``roi`` type column will be appended containing ROI IDs.
+If the target is an Image, a csv with ROI-level and object-level data can be used to create an
+``OMERO.table`` (bulk annotation) as a ``File Annotation`` on an Image.
+The ROI identifying column can be an ``roi`` type column containing ROI ID, and ``Roi Name``
+column will be appended automatically (see example below). Alternatively, the input column can be
+``Roi Name`` (with type ``s``), and an ``roi`` type column will be appended containing ROI IDs.
+In *both* cases, it is required that ROIs on the Image in OMERO have the ``Name`` attribute set.
 
 image.csv::
 

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -239,6 +239,9 @@ class MetadataControl(BaseControl):
         populate.add_argument("--localcfg", help=(
             "Local configuration file or a JSON object string"))
 
+        populate.add_argument("--allow_nan", action="store_true", help=(
+            "Allow empty values to become Nan in Long or Double columns"))
+
         populateroi.add_argument(
             "--measurement", type=int, default=None,
             help="Index of the measurement to populate. By default, all")
@@ -529,7 +532,8 @@ class MetadataControl(BaseControl):
         ctx = context_class(client, args.obj, file=args.file, fileid=fileid,
                             cfg=args.cfg, cfgid=cfgid, attach=args.attach,
                             options=localcfg, batch_size=args.batch,
-                            loops=loops, ms=ms, dry_run=args.dry_run)
+                            loops=loops, ms=ms, dry_run=args.dry_run,
+                            allow_nan=args.allow_nan)
         ctx.parse()
 
     def rois(self, args):

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -464,6 +464,7 @@ class ValueResolver(object):
         if len(value) == 0 and (LongColumn is column_class or
                                 DoubleColumn is column_class):
             if self.allow_nan:
+                log.debug('NaN value for column: %s' % column.name)
                 return float("NaN")
             else:
                 raise TypeError("Empty Double or Long value. "

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -467,7 +467,7 @@ class ValueResolver(object):
                 log.debug('NaN value for column: %s' % column.name)
                 return float("NaN")
             else:
-                raise TypeError("Empty Double or Long value. "
+                raise ValueError("Empty Double or Long value. "
                                 "Use --allow_nan to convert to NaN")
         if LongColumn is column_class:
             return int(value)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -468,7 +468,7 @@ class ValueResolver(object):
                 return float("NaN")
             else:
                 raise ValueError("Empty Double or Long value. "
-                                "Use --allow_nan to convert to NaN")
+                                 "Use --allow_nan to convert to NaN")
         if LongColumn is column_class:
             return int(value)
         if DoubleColumn is column_class:

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -461,9 +461,15 @@ class ValueResolver(object):
         if StringColumn is column_class:
             return value
         if LongColumn is column_class:
-            return int(value)
+            try:
+                return int(value)
+            except ValueError:
+                return float("NaN")
         if DoubleColumn is column_class:
-            return float(value)
+            try:
+                return float(value)
+            except ValueError:
+                return float("NaN")
         if BoolColumn is column_class:
             return value.lower() in BOOLEAN_TRUE
         raise MetadataError('Unsupported column class: %s' % column_class)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -462,7 +462,7 @@ class ValueResolver(object):
         if StringColumn is column_class:
             return value
         if len(value) == 0 and (LongColumn is column_class or
-                DoubleColumn is column_class):
+                                DoubleColumn is column_class):
             if self.allow_nan:
                 return float("NaN")
             else:

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -742,7 +742,8 @@ class Image2Rois(Fixture):
         if not self.image:
             image = self.test.make_image()
             # reload image to avoid unloaded exceptions etc.
-            self.image = self.test.client.sf.getQueryService().get('Image', image.id.val)
+            self.image = self.test.client.sf.getQueryService().get(
+                'Image', image.id.val)
             self.rois = self.create_rois()
         return self.image
 
@@ -994,7 +995,7 @@ class TestPopulateMetadataHelper(ITest):
         ctx = ParsingContext(self.client,
                              target,
                              file=csv,
-                             allow_nan=(allow_nan == True))
+                             allow_nan=(allow_nan is True))
 
         if allow_nan is False:
             with raises(ValueError):


### PR DESCRIPTION
When using `omero metadata populate --file data.csv` and the csv file specifies a `FloatColumn` should be used, empty cells cause a failure, even though there may be a valid use-case for missing values.
This PR allows missing values (empty string) by using a NaN value in the table.
When viewed in /webclient/omero_table/FILE_ID/ this is rendered as `nan` and is filtered out by any numerical queries, e.g.
`/webclient/omero_table/FILE_ID/?query=col_name>100` or `/webclient/omero_table/FILE_ID/?query=col_name<0`

See: https://idr-redmine.openmicroscopy.org/issues/201#note-25

Also updated README to fix `--file` (needed when passing csv to populate metadata) and to add a note about `roi.Name` needed when adding bulk annotations to Image: `omero metadata populate Image:123 --file data.csv`
