### PR TITLE
Close callbacks

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -2084,6 +2084,7 @@ class DeleteMapAnnotationContext(_QueryContext):
         # At this point, we're sure that there's a response OR
         # an exception has been thrown (likely LockTimeout)
         rsp = callback.getResponse()
+        callback.close(True)
         try:
             deleted = rsp.deletedObjects
             log.info("Deleted objects in %g s" % (time.time() - start))


### PR DESCRIPTION
If an error is thrown during submit() and closehandle is true,
then the callback is automatically closed. If not, then the
caller is required to call `cb.close(True)` which will remove
the callback servant. If this is *not* done, then the following
type of error will be thrown on map annotation deletion:

```
    serverExceptionClass = "ome.conditions.OverUsageException"
    message = "servantsPerSession reached for 36cb8357-997a-46ff-b421-5b08d97cd3fc: 10000"
````