### PR TITLE
Prevent users from creating columns with python keyword names

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -36,6 +36,7 @@ import sys
 import csv
 import re
 import json
+import keyword
 from getpass import getpass
 from getopt import getopt, GetoptError
 
@@ -225,6 +226,12 @@ class HeaderResolver(object):
     def columns_sanity_check(self, columns):
         column_types = [column.__class__ for column in columns]
         column_names = [column.name for column in columns]
+        lower_case_kws = [kw.lower() for kw in keyword.kwlist]
+        for col_name in column_names:
+            if col_name.lower() in lower_case_kws:
+                raise MetadataError(
+                ('Cannot use column name "' + col_name +
+                    '" because it is a reserved python keyword'))
         if WellColumn in column_types and ImageColumn in column_types:
             log.debug(column_types)
             raise MetadataError(


### PR DESCRIPTION
Queries for columns with names matching a python keyword fail. This change prevents the creation of such columns.