### PR TITLE
Use 'Roi' for name of RoiColumn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ In *both* cases, it is required that ROIs on the Image in OMERO have the ``Name`
 image.csv::
 
     # header roi,l,d,l
-    roi,object,probability,area
+    Roi,object,probability,area
     501,1,0.8,250
     502,1,0.9,500
     503,1,0.2,25
@@ -162,7 +162,7 @@ image.csv::
 This will create an OMERO.table linked to the Image like this:
 
 === ====== =========== ==== ========
-roi object probability area Roi Name
+Roi object probability area Roi Name
 === ====== =========== ==== ========
 501 1      0.8         250  Sample1
 502 1      0.9         500  Sample2

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1178,11 +1178,11 @@ class ParsingContext(object):
             for column in self.columns:
                 if not values:
                     if isinstance(column, ImageColumn) or \
+                       isinstance(column, RoiColumn) or \
                        column.name in (PLATE_NAME_COLUMN,
                                        WELL_NAME_COLUMN,
                                        IMAGE_NAME_COLUMN,
-                                       ROI_NAME_COLUMN,
-                                       'Roi'):
+                                       ROI_NAME_COLUMN):
                         # Then assume that the values will be calculated
                         # later based on another column.
                         continue

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -298,9 +298,11 @@ class HeaderResolver(object):
             if column.__class__ is PlateColumn:
                 append.append(StringColumn(PLATE_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))
+                column.name = "Plate"
             if column.__class__ is WellColumn:
                 append.append(StringColumn(WELL_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))
+                column.name = "Well"
             if column.__class__ is ImageColumn:
                 append.append(StringColumn(IMAGE_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -304,12 +304,16 @@ class HeaderResolver(object):
             if column.__class__ is ImageColumn:
                 append.append(StringColumn(IMAGE_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))
-            # Currently hard-coded, but "if image name, then add image id"
-            if column.name == IMAGE_NAME_COLUMN:
-                append.append(ImageColumn("Image", '', list()))
+                # Ensure ImageColumn is named "Image"
+                column.name = "Image"
             if column.__class__ is RoiColumn:
                 append.append(StringColumn(ROI_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))
+                # Ensure RoiColumn is named 'Roi'
+                column.name = "Roi"
+            # If image/roi name, then add ID column"
+            if column.name == IMAGE_NAME_COLUMN:
+                append.append(ImageColumn("Image", '', list()))
             if column.name == ROI_NAME_COLUMN:
                 append.append(RoiColumn("Roi", '', list()))
         if self.columns_sanity_check(columns):

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -311,7 +311,7 @@ class HeaderResolver(object):
                 append.append(StringColumn(ROI_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))
             if column.name == ROI_NAME_COLUMN:
-                append.append(RoiColumn("roi", '', list()))
+                append.append(RoiColumn("Roi", '', list()))
         if self.columns_sanity_check(columns):
             columns.extend(append)
         return columns
@@ -1178,7 +1178,7 @@ class ParsingContext(object):
                                        WELL_NAME_COLUMN,
                                        IMAGE_NAME_COLUMN,
                                        ROI_NAME_COLUMN,
-                                       'roi'):
+                                       'Roi'):
                         # Then assume that the values will be calculated
                         # later based on another column.
                         continue

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -167,8 +167,12 @@ class Fixture(object):
     def get_namespaces(self):
         return [NSBULKANNOTATIONS]
 
-    def assert_rows(self, rows):
+    def assert_row_count(self, rows):
         assert rows == self.row_count * self.col_count
+
+    def assert_columns(self, columns):
+        col_names = "Well,Well Type,Concentration,Well Name"
+        assert col_names == ",".join([c.name for c in columns])
 
     def assert_child_annotations(self, oas):
         for ma, wid, wr, wc in oas:
@@ -206,11 +210,16 @@ class Screen2Plates(Fixture):
                       "P002,A1,Control,0", "P002,A2,Treatment,10"))
         self.screen = None
 
-    def assert_rows(self, rows):
+    def assert_row_count(self, rows):
         """
         Double the number of rows due to 2 plates.
         """
         assert rows == 2 * self.row_count * self.col_count
+
+    def assert_columns(self, columns):
+        # Adds Plate Name,Well Name columns
+        col_names = "Plate,Well,Well Type,Concentration,Plate Name,Well Name"
+        assert col_names == ",".join([c.name for c in columns])
 
     def get_target(self):
         if not self.screen:
@@ -574,6 +583,10 @@ class Plate2WellsNs2UnavailableHeader(Plate2WellsNs2):
         )
         self.plate = None
 
+    def assert_columns(self, columns):
+        col_names = "Well,Gene,Gene Names"
+        assert col_names == ",".join([c.name for c in columns])
+
     def get_cfg(self):
         return os.path.join(os.path.dirname(__file__),
                             'bulk_to_map_annotation_context_ns2_empty.yml')
@@ -636,6 +649,10 @@ class Plate2WellsNs2Fail(Plate2WellsNs2):
         )
         self.plate = None
 
+    def assert_columns(self, columns):
+        col_names = "Well,Gene,Gene Names"
+        assert col_names == ",".join([c.name for c in columns])
+
     def get_cfg(self):
         return os.path.join(os.path.dirname(__file__),
                             'bulk_to_map_annotation_context_ns2_fail.yml')
@@ -656,7 +673,12 @@ class Dataset2Images(Fixture):
         self.images = None
         self.names = ("A1", "A2")
 
-    def assert_rows(self, rows):
+    def assert_columns(self, columns):
+        # adds "Image" column to table
+        col_names = "Image Name,Type,Concentration,Image"
+        assert col_names == ",".join([c.name for c in columns])
+
+    def assert_row_count(self, rows):
         # Hard-coded in createCsv's arguments
         assert rows == 2
 
@@ -734,7 +756,12 @@ class Image2Rois(Fixture):
         self.rois = None
         self.names = ("roi1", "roi2")
 
-    def assert_rows(self, rows):
+    def assert_columns(self, columns):
+        # Adds a new 'Roi' column
+        col_names = "Roi Name,Feature,Concentration,Count,Roi"
+        assert col_names == ",".join([c.name for c in columns])
+
+    def assert_row_count(self, rows):
         # Hard-coded in createCsv's arguments
         assert rows == 2
 
@@ -833,7 +860,11 @@ class Dataset101Images(Dataset2Images):
         self.dataset = None
         self.images = None
 
-    def assert_rows(self, rows):
+    def assert_columns(self, columns):
+        col_names = "Image Name,Type,Concentration,Image"
+        assert col_names == ",".join([c.name for c in columns])
+
+    def assert_row_count(self, rows):
         assert rows == 102
 
 
@@ -859,6 +890,10 @@ class Unicode(Plate2Wells):
             row_data=(u"A1,Control,0,მიკროსკოპის", u"A2,Treatment,10,პონი"),
             encoding="utf-8")
 
+    def assert_columns(self, columns):
+        col_names = "Well,Well Type,Concentration,Extra type,Well Name"
+        assert col_names == ",".join([c.name for c in columns])
+
 
 class UnicodeBOM(Plate2Wells):
 
@@ -869,6 +904,10 @@ class UnicodeBOM(Plate2Wells):
             col_names="Well,Well Type,Concentration,Extra type",
             row_data=("A1,Control,0,მიკროსკოპის", "A2,Treatment,10,პონი"),
             encoding="utf-8-sig")
+
+    def assert_columns(self, columns):
+        col_names = "Well,Well Type,Concentration,Extra type,Well Name"
+        assert col_names == ",".join([c.name for c in columns])
 
 
 class Project2Datasets(Fixture):
@@ -882,7 +921,11 @@ class Project2Datasets(Fixture):
                       "D002,A1,Control,0", "D002,A2,Treatment,10"))
         self.project = None
 
-    def assert_rows(self, rows):
+    def assert_columns(self, columns):
+        col_names = "Dataset Name,Image Name,Type,Concentration,Image"
+        assert col_names == ",".join([c.name for c in columns])
+
+    def assert_row_count(self, rows):
         # Hard-coded in create_csv's arguments
         assert rows == 4
 
@@ -1020,7 +1063,8 @@ class TestPopulateMetadataHelper(ITest):
     def _assert_parsing_context_values(self, t, fixture):
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
-        fixture.assert_rows(rows)
+        fixture.assert_row_count(rows)
+        fixture.assert_columns(cols)
         for hit in range(rows):
             row_values = [col.values[0] for col in t.read(
                 list(range(len(cols))), hit, hit+1).columns]
@@ -1149,7 +1193,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
 
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
-        fixture.assert_rows(rows)
+        fixture.assert_row_count(rows)
         data = [c.values for c in t.read(
             list(range(len(cols))), 0, rows).columns]
         row_values = list(zip(*data))


### PR DESCRIPTION
This uses the name "Roi" for the `RoiColumn`, using the same convention we have adopted of "Image" for the `ImageColumn`.

I noticed @sbesson had 'Roi' column on his screenshot at https://github.com/ome/omero-web/pull/264#issuecomment-786023860

I was looking at loading a row for a particular ROI using:
```
/webgateway/table/Image/2567/query/?query=Roi-225611
```

To test:
 - See image with ROIs at https://merge-ci.openmicroscopy.org/web/webclient/?show=image-39715
 - Download the CSV attached - confirm it looks like this (NB: 1st column Name is `roi`).

```
# header roi,d,l,s
roi,ROI_Area,Channel_Index,Channel_Name
418817,0.0469,1,DAPI
418818,0.142,2,GFP
418819,0.093,3,TRITC
418820,0.093,3,ACA
418821,0.093,3,foo
```

 - Run the `Populate_Metadata.py` script on this image (can use the webclient UI and this also tests https://github.com/ome/omero-scripts/pull/184).
 - Open the Table in webclient and check that the first column is named `Roi` (not `roi`) - and that rest of the table is correct.
