### PR TITLE
Roi name allowed none

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ If the target is an Image, a csv with ROI-level and object-level data can be use
 The ROI identifying column can be an ``roi`` type column containing ROI ID, and ``Roi Name``
 column will be appended automatically (see example below). Alternatively, the input column can be
 ``Roi Name`` (with type ``s``), and an ``roi`` type column will be appended containing ROI IDs.
-In *both* cases, it is required that ROIs on the Image in OMERO have the ``Name`` attribute set.
+In this case, it is required that ROIs on the Image in OMERO have the ``Name`` attribute set.
 
 image.csv::
 

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -896,7 +896,7 @@ class ImageWrapper(ValueWrapper):
         return self.rois_by_name[rname].id.val
 
     def get_roi_name_by_id(self, rid):
-        return self.rois_by_id[rid].name.val
+        return unwrap(self.rois_by_id[rid].name)
 
     def resolve_roi(self, column, row, value):
         try:
@@ -940,10 +940,10 @@ class ImageWrapper(ValueWrapper):
         for roi in data:
             rid = roi.id.val
             rois_by_id[rid] = roi
-            if roi.name.val in rois_by_name.keys():
+            if unwrap(roi.name) in rois_by_name.keys():
                 log.warn('Conflicting ROI names.')
                 self.ambiguous_naming = True
-            rois_by_name[roi.name.val] = roi
+            rois_by_name[unwrap(roi.name)] = roi
         self.rois_by_id = rois_by_id
         self.rois_by_name = rois_by_name
         log.debug('Completed parsing image: %s' % self.target_name)
@@ -1397,6 +1397,8 @@ class ParsingContext(object):
                     log.debug(roi_column)
                     rid = roi_column.values[i]
                     rname = self.value_resolver.get_roi_name_by_id(rid)
+                    if rname is None:
+                        rname = ""
                 except KeyError:
                     log.warn(
                         "%d not found in roi ids" % rid)


### PR DESCRIPTION
In the case when we `populate metadata` on a target Image with a csv as in the README (below), the ROI IDs are already in the csv and we don't need the ROI.name in OMERO to identify which row applies to which ROI.
However, without this PR, any ROIs without the `name` set in OMERO would cause `populate metadata` to fail.

```
    # header roi,l,d,l
    Roi,Shape,probability,area
    501,1,0.8,250
    502,1,0.9,500
    503,1,0.2,25
```

To test:
 - Draw some Shapes on an Image in iviewer and Save
 - Note the ROI IDs from iviewer and update the ROIs in a csv like the one above.
 - Run `populate metadata` script on the Image in webclient with the csv (this requires https://github.com/ome/omero-scripts/pull/184) or use the CLI.
 - Should get an OMERO.table created on the Image with a `Roi Name` column where all the values will be empty
 - Bonus: If you also include a `Shape` column of type `l` with the correct Shape values, it should be possible to use this OMERO.table to create a heatmap on those Shapes in OMERO.figure as described in https://github.com/ome/omero-guide-figure/pull/11 

cc @pwalczysko 