### PR TITLE
add allow_nan flag to context

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1545,7 +1545,8 @@ class BulkToMapAnnotationContext(_QueryContext):
 
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, options=None,
-                 batch_size=1000, loops=10, ms=10, dry_run=False):
+                 batch_size=1000, loops=10, ms=10, dry_run=False,
+                 allow_nan=False):
         """
         :param client: OMERO client object
         :param target_object: The object to be annotated
@@ -1877,7 +1878,8 @@ class DeleteMapAnnotationContext(_QueryContext):
 
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, options=None,
-                 batch_size=1000, loops=10, ms=500, dry_run=False):
+                 batch_size=1000, loops=10, ms=500, dry_run=False,
+                 allow_nan=False):
 
         """
         :param client: OMERO client object


### PR DESCRIPTION
The problem appears when I ran 
```
omero metadata populate --context bulkmap --batch 100 --cfg idr0113-experimentA-bulkmap-config.yml Project:1855
```


the change was tested in the context above
```
omero metadata populate --context bulkmap --batch 100 --cfg idr0113-experimentA-bulkmap-config.yml Project:1855
Using session for demo@localhost:4064. Idle timeout: 10 min. Current group: Public
_save_annotation_and_links with batch size 100
INFO:omero_metadata.populate:Created/linked 110 MapAnnotations (total 110)
INFO:omero_metadata.populate:Created/linked 100 MapAnnotations (total 210)
INFO:omero_metadata.populate:Created/linked 10 MapAnnotations (total 220)
```

cc @sbesson 