### PR TITLE
Add table_name option to ParsingContext()

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1013,6 +1013,8 @@ class ParsingContext(object):
                                                        target_object,
                                                        self.value_resolver)
         self.dry_run = dry_run
+        if not table_name:
+            table_name = DEFAULT_TABLE_NAME     # just in case
         self.table_name = table_name
 
     def create_annotation_link(self):

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -988,7 +988,7 @@ class ParsingContext(object):
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, column_types=None,
                  options=None, batch_size=1000, loops=10, ms=500,
-                 dry_run=False, allow_nan=False):
+                 dry_run=False, allow_nan=False, table_name=None):
         '''
         This lines should be handled outside of the constructor:
 
@@ -1012,6 +1012,7 @@ class ParsingContext(object):
                                                        target_object,
                                                        self.value_resolver)
         self.dry_run = dry_run
+        self.table_name = table_name
 
     def create_annotation_link(self):
         self.target_class = self.target_object.__class__
@@ -1102,8 +1103,9 @@ class ParsingContext(object):
         sf = self.client.getSession()
         group = str(self.value_resolver.target_group)
         sr = sf.sharedResources()
-        table = sr.newTable(1, DEFAULT_TABLE_NAME,
-                            {'omero.group': native_str(group)})
+        name = self.table_name if self.table_name is not None \
+            else DEFAULT_TABLE_NAME
+        table = sr.newTable(1, name, {'omero.group': native_str(group)})
         if table is None:
             raise MetadataError(
                 "Unable to create table: %s" % DEFAULT_TABLE_NAME)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -988,7 +988,8 @@ class ParsingContext(object):
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, column_types=None,
                  options=None, batch_size=1000, loops=10, ms=500,
-                 dry_run=False, allow_nan=False, table_name=None):
+                 dry_run=False, allow_nan=False,
+                 table_name=DEFAULT_TABLE_NAME):
         '''
         This lines should be handled outside of the constructor:
 
@@ -1103,9 +1104,8 @@ class ParsingContext(object):
         sf = self.client.getSession()
         group = str(self.value_resolver.target_group)
         sr = sf.sharedResources()
-        name = self.table_name if self.table_name is not None \
-            else DEFAULT_TABLE_NAME
-        table = sr.newTable(1, name, {'omero.group': native_str(group)})
+        table = sr.newTable(1, self.table_name,
+                            {'omero.group': native_str(group)})
         if table is None:
             raise MetadataError(
                 "Unable to create table: %s" % DEFAULT_TABLE_NAME)

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -1018,7 +1018,7 @@ class TestPopulateMetadataConfigLoad(ITest):
 
 class TestPopulateMetadataHelper(ITest):
 
-    def _test_parsing_context(self, fixture, batch_size):
+    def _test_parsing_context(self, fixture):
         """
             Create a small csv file, use populate_metadata.py to parse and
             attach to Plate. Then query to check table has expected content.
@@ -1174,7 +1174,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         now just run them all together
         """
         fixture.init(self)
-        t = self._test_parsing_context(fixture, batch_size)
+        t = self._test_parsing_context(fixture)
         if t is None:
             return
         self._assert_parsing_context_values(t, fixture)
@@ -1189,7 +1189,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         annotations on multiple OMERO data types
         """
         fixture.init(self)
-        t = self._test_parsing_context(fixture, 2)
+        t = self._test_parsing_context(fixture)
 
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
@@ -1210,7 +1210,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         """
         fixture_empty = Plate2WellsNs2UnavailableHeader()
         fixture_empty.init(self)
-        self._test_parsing_context(fixture_empty, 2)
+        self._test_parsing_context(fixture_empty)
         self._test_bulk_to_map_annotation_context(fixture_empty, 2)
 
     def test_populate_metadata_ns_anns_fail(self):
@@ -1220,7 +1220,7 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         """
         fixture_fail = Plate2WellsNs2Fail()
         fixture_fail.init(self)
-        self._test_parsing_context(fixture_fail, 2)
+        self._test_parsing_context(fixture_fail)
         with raises(MapAnnotationPrimaryKeyException):
             self._test_bulk_to_map_annotation_context(fixture_fail, 2)
 
@@ -1348,12 +1348,12 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelperPerMethod):
         """
         fixture1 = Plate2WellsNs2()
         fixture1.init(self)
-        self._test_parsing_context(fixture1, 2)
+        self._test_parsing_context(fixture1)
         self._test_bulk_to_map_annotation_context(fixture1, 2)
 
         fixture2 = Plate2WellsNs2()
         fixture2.init(self)
-        self._test_parsing_context(fixture2, 2)
+        self._test_parsing_context(fixture2)
         self._test_bulk_to_map_annotation_dedup(fixture1, fixture2, ns)
 
     @mark.parametrize("ns", [None, NSBULKANNOTATIONS, MAPR_NS_GENE])
@@ -1364,12 +1364,12 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelperPerMethod):
         """
         fixture1 = Plate2WellsNs2()
         fixture1.init(self)
-        self._test_parsing_context(fixture1, 2)
+        self._test_parsing_context(fixture1)
         self._test_bulk_to_map_annotation_context(fixture1, 2)
 
         fixture2 = Plate2WellsNs2()
         fixture2.init(self)
-        self._test_parsing_context(fixture2, 2)
+        self._test_parsing_context(fixture2)
         self._test_bulk_to_map_annotation_dedup(fixture1, fixture2, None)
         self._test_delete_map_annotation_context_dedup(
             fixture1, fixture2, ns)

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -1032,7 +1032,7 @@ class TestPopulateMetadataHelper(ITest):
         allow_nan = None
         if hasattr(fixture, 'allow_nan'):
             allow_nan = fixture.allow_nan
-        kwargs['allow_nan'] = allow_nan
+            kwargs['allow_nan'] = allow_nan
 
         expected_table_name = 'bulk_annotations'
         if hasattr(fixture, 'table_name'):


### PR DESCRIPTION
See https://github.com/IDR/idr0079-hartmann-lateralline/pull/5#issuecomment-901249131

Usage:
```
    ctx = ParsingContext(
        client, image._obj, file=csv_name, allow_nan=True,
        table_name=table_name
    )
    ctx.parse()
```
This change used in https://github.com/IDR/idr0079-hartmann-lateralline/pull/5/commits/57e507fe24f34170d5b60a91e709ff6218bfbabd
to create bulk annotations with custom names:

<img width="356" alt="Screenshot 2021-08-18 at 22 28 56" src="https://user-images.githubusercontent.com/900055/129974800-e6c1a51b-7aa2-4308-b688-0db10f65a8a6.png">

NB: `ParsingContext()` has several parameters that are not used: `fileid`, `cfg`, `cfgid`, `attach`, `options`, `batch_size`, `loops`, `ms`. Seems like these should be removed, although that will break code that still includes them.