### PR TITLE
Support ROI table on Dataset, for table with ROI ID column

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -253,6 +253,7 @@ class HeaderResolver(object):
         return self._create_columns("image")
 
     def _create_columns(self, klass):
+        target_class = self.target_object.__class__
         if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
@@ -308,7 +309,7 @@ class HeaderResolver(object):
                               self.DEFAULT_COLUMN_SIZE, list()))
                 # Ensure ImageColumn is named "Image"
                 column.name = "Image"
-            if column.__class__ is RoiColumn:
+            if column.__class__ is RoiColumn and target_class != DatasetI:
                 append.append(StringColumn(ROI_NAME_COLUMN, '',
                               self.DEFAULT_COLUMN_SIZE, list()))
                 # Ensure RoiColumn is named 'Roi'
@@ -758,6 +759,10 @@ class DatasetWrapper(PDIWrapper):
         self.images_by_id = dict()
         self.images_by_name = dict()
         self._load()
+
+    def resolve_roi(self, column, row, value):
+        # Support Dataset table with known ROI IDs
+        return int(value)
 
     def get_image_id_by_name(self, iname, dname=None):
         return self.images_by_name[iname].id.val


### PR DESCRIPTION
This supports work on idr0123 where we are looking to create a Table with ROIs linked to a Dataset.

The table has an `roi` column so we know the ROI IDs already and we don't load any ROIs or add an `Roi Name` column.

NB: Quite often in these workflows, I am creating a csv table that has all the data I need (don't need to do any resolving between object names), and it feels quite hard to simply turn this table into an OMERO table with `populate.py` because it's designed to do object name resolution. So maybe I'm not using the right tool for the job.
Although the above changes are quite small, they took quite a while to figure out!

E.g. I really just want a `create_table(csv)` command that simply creates an OMERO.table from the csv as-is, possibly using a `#header` of column types, but not doing any other look-ups etc. I think this has also been requested by users