### PR TITLE
Support images_by_name for Screen and Plate

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -701,6 +701,10 @@ class PlateWrapper(SPWWrapper):
         wells = self.wells_by_id[plate]
         return wells[well_id]
 
+    def get_image_id_by_name(self, iname, pid=None):
+        plate = self.target_object.id.val
+        return self.images_by_name[plate][iname].id.val
+
     def subselect(self, rows, names):
         """
         If we're processing a plate but the bulk-annotations file contains
@@ -1400,13 +1404,11 @@ class ParsingContext(object):
                 iname = image_name_column.values[i]
                 iid = -1
                 try:
+                    # If target class is Screen, a plate column should exist
                     if "plate" in columns_by_name:
                         pid = int(columns_by_name["plate"].values[i])
-                    elif "plate name" in columns_by_name \
-                            and target_class is not PlateI:
-                        pname = columns_by_name["plate name"].values[i]
-                        pid = self.value_resolver.wrapper.plates_by_name[
-                            pname].id.val
+                    elif target_class is PlateI:
+                        pid = self.target_object.id.val
                     log.debug("Using Plate:%d" % pid)
                     iid = self.value_resolver.get_image_id_by_name(
                         iname, pid)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -27,7 +27,7 @@ from __future__ import print_function
 from builtins import chr
 from builtins import str
 from builtins import range
-from future.utils import isidentifier, native_str
+from future.utils import native_str
 from past.builtins import basestring
 from builtins import object
 import logging
@@ -563,7 +563,8 @@ class SPWWrapper(ValueWrapper):
             raise Exception("Cannot resolve image to plate")
         return self.images_by_id[pid][iid].name.val
 
-    def parse_plate(self, plate, wells_by_location, wells_by_id, images_by_id, images_by_name):
+    def parse_plate(self, plate, wells_by_location, wells_by_id,
+                    images_by_id, images_by_name):
         """
         Accepts PlateData instances
         """
@@ -686,7 +687,8 @@ class ScreenWrapper(SPWWrapper):
             images_by_name = dict()
             self.images_by_name[plate.id.val] = images_by_name
             self.parse_plate(
-                plate, wells_by_location, wells_by_id, images_by_id, images_by_name
+                plate, wells_by_location, wells_by_id,
+                images_by_id, images_by_name
             )
 
 
@@ -1139,7 +1141,7 @@ class ParsingContext(object):
                     return self.parse_from_handle_stream(f2)
 
     def preprocess_data(self, reader):
-        for row in reader:
+        for i, row in enumerate(reader):
             row = [(self.columns[i], value) for i, value in enumerate(row)]
             for column, original_value in row:
                 log.debug('Original value %s, %s',
@@ -1362,9 +1364,10 @@ class ParsingContext(object):
                     resolve_image_ids and not resolve_image_names:
                 # PDI - need to know Image IDs from Names
                 iid = -1
-                log.debug(image_column)
-                iname = image_name_column.values[i]
                 try:
+                    log.debug(image_column)
+                    iname = image_name_column.values[i]
+                    did = self.target_object.id.val
                     if "dataset name" in columns_by_name \
                             and target_class is not DatasetI:
                         dname = columns_by_name["dataset name"].values[i]

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -153,7 +153,8 @@ class Fixture(object):
             for well in plate.listChildren():
                 for field_index, ws in enumerate(well.listChildren()):
                     img = ws.getImage()._obj
-                    img.name = rstring(f'{ well.getWellPos() }_Field-{field_index}')
+                    img.name = rstring(
+                        f'{ well.getWellPos() }_Field-{field_index}')
                     img = update.saveAndReturnObject(img)
                     images_by_id[img.id.val] = img
         plate1 = self.set_name(plate1, "P001")
@@ -235,8 +236,10 @@ class Screen2Plates(Fixture):
         self.col_count = 2
         self.csv = self.create_csv(
             col_names="Plate,Well,Image Name,Well Type,Concentration",
-            row_data=("P001,A1,A1_Field-0,Control,0", "P001,A2,A2_Field-0,Treatment,10",
-                      "P002,A1,A1_Field-0,Control,0", "P002,A2,A2_Field-0,Treatment,10"))
+            row_data=("P001,A1,A1_Field-0,Control,0",
+                      "P001,A2,A2_Field-0,Treatment,10",
+                      "P002,A1,A1_Field-0,Control,0",
+                      "P002,A2,A2_Field-0,Treatment,10"))
         self.screen = None
 
     def assert_row_count(self, rows):
@@ -247,7 +250,8 @@ class Screen2Plates(Fixture):
 
     def assert_columns(self, columns):
         # Adds Plate Name,Well Name, Image columns
-        col_names = "Plate,Well,Image Name,Well Type,Concentration,Plate Name,Well Name,Image"
+        col_names = ("Plate,Well,Image Name,Well Type,"
+                     "Concentration,Plate Name,Well Name,Image")
         assert col_names == ",".join([c.name for c in columns])
 
     def assert_table_row(self, row_values, row_index):


### PR DESCRIPTION
See #63.

Supports parsing `Image Name` to Image ID for HCS data. `Image Name` must be unique to a Plate (similar to Dataset).

NB: There has been a long-standing inconsistency in the way that populate metadata handles column names for PDI vv HCS. 
For PDI, you start with "Image Name" column (with `s` type in header) in your csv. A new "Image" column is added with Image IDs.
This seems to make the most sense.
For HCS, you start with "Well" column (with `well` type in header), that contains the Well Names. This column is converted to a Well ID column (still named Well) and a new `Well Name` column is added, containing the names that were in the `Well` column. This is confusing!

In this case, so as not to have different handling of `Image Name` columns for HCS vv PDI, we need an `Image Name` column (type: `s`) alongside a `Well` column (type: `well`), even though they both contain names!

E.g. screen.csv
```
# header plate,well,s,s
Plate,Well,Image Name,Drug_name
plate1,A1,well 1 field 1, DMSO
plate1,A1,well 1 field 2, DMSO
plate1,A2,well 2 field 1, Drug1
plate1,A2,well 2 field 2, Drug1
```

E.g. plate.csv
```
# header well,s,s
Well,Image Name,Drug_name
A1,well 1 field 1, DMSO
A1,well 1 field 2, DMSO
A2,well 2 field 1, Drug1
A2,well 2 field 2, Drug1
```

TODO: add tests...