### PR TITLE
Add --detect_header and DatasetColumn support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,8 @@ setup(
         'future',
         'omero-py>=5.6.0',
         'PyYAML',
-        'jinja2'
+        'jinja2',
+        'pandas'
     ],
     python_requires='>=3',
     tests_require=[

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -245,7 +245,7 @@ class MetadataControl(BaseControl):
             "Allow empty values to become Nan in Long or Double columns"))
 
         populate.add_argument("--manual_header", action="store_true", help=(
-            "Disable automatic header detection row to populate"))
+            "Disable automatic header detection during population"))
 
         populateroi.add_argument(
             "--measurement", type=int, default=None,
@@ -574,7 +574,7 @@ class MetadataControl(BaseControl):
         # Check if first row contains `# header`
         first_row = pd.read_csv(args.file, nrows=1, header=None)
         if not args.manual_header and \
-                not first_row[0].str.contains('# header'):
+                not first_row[0].str.contains('# header').bool():
             omero_metadata.populate.log.info("Detecting header types")
             header_type = self.detect_headers(args.file)
             if args.dry_run:

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -504,12 +504,15 @@ class MetadataControl(BaseControl):
             col = cols[index]
             if col.lower() in conserved_headers:
                 headers.append(col.lower())
-            elif col.lower() == 'image name' or col.lower() == 'imagename' or \
-                    col.lower() == 'image_name':
+            elif col.lower() == 'image id' or col.lower() == 'imageid' or \
+                    col.lower() == 'image_id':
                 headers.append('image')
-            elif col.lower() == 'dataset name' or \
-                    col.lower() == 'datasetname' or \
-                    col.lower() == 'dataset_name':
+            elif col.lower() == 'roi id' or col.lower() == 'roiid' or \
+                    col.lower() == 'roi_id':
+                headers.append('roi')
+            elif col.lower() == 'dataset id' or \
+                    col.lower() == 'datasetid' or \
+                    col.lower() == 'dataset_id':
                 headers.append('dataset')
             elif col.lower() == 'plate name' or col.lower() == 'platename' or \
                     col.lower() == 'plate_name':

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -505,16 +505,17 @@ class MetadataControl(BaseControl):
             if col.lower() in conserved_headers:
                 headers.append(col.lower())
             elif col.lower() == 'image name' or col.lower() == 'imagename' or \
-            col.lower() == 'image_name':
+                    col.lower() == 'image_name':
                 headers.append('image')
-            elif col.lower() == 'dataset name' or col.lower() == 'datasetname' or \
-            col.lower() == 'dataset_name':
+            elif col.lower() == 'dataset name' or \
+                    col.lower() == 'datasetname' or \
+                    col.lower() == 'dataset_name':
                 headers.append('dataset')
             elif col.lower() == 'plate name' or col.lower() == 'platename' or \
-            col.lower() == 'plate_name':
+                    col.lower() == 'plate_name':
                 headers.append('plate')
             elif col.lower() == 'well name' or col.lower() == 'wellname' or \
-            col.lower() == 'well_name':
+                    col.lower() == 'well_name':
                 headers.append('well')
             elif col_type.name == 'object':
                 headers.append('s')

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -488,7 +488,8 @@ class MetadataControl(BaseControl):
         if not initialized:
             self.ctx.die(100, "Failed to initialize Table")
 
-    def detect_headers(self, csv_path):
+    @staticmethod
+    def detect_headers(csv_path):
         '''
         Function to automatically detect headers from a CSV file. This function
         loads the table to pandas to detects the column type and match headers
@@ -576,7 +577,7 @@ class MetadataControl(BaseControl):
         if not args.manual_header and \
                 not first_row[0].str.contains('# header').bool():
             omero_metadata.populate.log.info("Detecting header types")
-            header_type = self.detect_headers(args.file)
+            header_type = MetadataControl.detect_headers(args.file)
             if args.dry_run:
                 omero_metadata.populate.log.info(f"Header Types:{header_type}")
         else:

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -569,7 +569,6 @@ class MetadataControl(BaseControl):
             header_type = self.detect_headers(args.file)
             if args.dry_run:
                 omero_metadata.populate.log.info(f"Header Types:{header_type}")
-        # add condition col_type = blarg, open arg.file, arg.detect_header
         loops = 0
         ms = 0
         wait = args.wait

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1556,7 +1556,7 @@ class BulkToMapAnnotationContext(_QueryContext):
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, options=None,
                  batch_size=1000, loops=10, ms=10, dry_run=False,
-                 allow_nan=False):
+                 allow_nan=False, **kwargs):
         """
         :param client: OMERO client object
         :param target_object: The object to be annotated
@@ -1889,7 +1889,7 @@ class DeleteMapAnnotationContext(_QueryContext):
     def __init__(self, client, target_object, file=None, fileid=None,
                  cfg=None, cfgid=None, attach=False, options=None,
                  batch_size=1000, loops=10, ms=500, dry_run=False,
-                 allow_nan=False):
+                 allow_nan=False, **kwargs):
 
         """
         :param client: OMERO client object

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -416,8 +416,6 @@ class ValueResolver(object):
                         )
                         break
                     elif column.name.lower() == "dataset name":
-                        # DatasetColumn unimplemented at the momnet
-                        # We can still access column names though
                         images_by_id = self.wrapper.images_by_id[
                             self.wrapper.datasets_by_name[column_value].id.val
                         ]
@@ -427,8 +425,6 @@ class ValueResolver(object):
                         )
                         break
                     elif column.name.lower() == "dataset":
-                        # DatasetColumn unimplemented at the momnet
-                        # We can still access column names though
                         images_by_id = self.wrapper.images_by_id[
                             self.wrapper.datasets_by_id[
                                 int(column_value)].id.val
@@ -825,7 +821,10 @@ class ProjectWrapper(PDIWrapper):
 
     def resolve_dataset(self, column, row, value):
         try:
-            return self.datasets_by_name[value].id.val
+            if column.name.lower() == 'dataset':
+                return self.datasets_by_id[int(value)].id.val
+            else:
+                return self.datasets_by_name[value].id.val
         except KeyError:
             log.warn('Project is missing dataset: %s' % value)
             return Skip()
@@ -1159,6 +1158,8 @@ class ParsingContext(object):
                     elif column.name.lower() is ROI_NAME_COLUMN:
                         column.values.append(value)
                     elif column.name.lower() == "plate":
+                        column.values.append(value)
+                    elif column.name.lower() == "dataset":
                         column.values.append(value)
                 except TypeError:
                     log.error('Original value "%s" now "%s" of bad type!' % (

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -314,8 +314,10 @@ class HeaderResolver(object):
                 # Ensure RoiColumn is named 'Roi'
                 column.name = "Roi"
             if column.__class__ is DatasetColumn:
-                append.append(StringColumn(DATASET_NAME_COLUMN, '',
-                              self.DEFAULT_COLUMN_SIZE, list()))
+                # This breaks the code, as currently there is no implementation
+                # of a method to populate the 'Dataset Name' column
+                # append.append(StringColumn(DATASET_NAME_COLUMN, '',
+                #               self.DEFAULT_COLUMN_SIZE, list()))
                 # Ensure DatasetColumn is named 'Dataset'
                 column.name = "Dataset"
             # If image/roi name, then add ID column"

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -313,6 +313,11 @@ class HeaderResolver(object):
                               self.DEFAULT_COLUMN_SIZE, list()))
                 # Ensure RoiColumn is named 'Roi'
                 column.name = "Roi"
+            if column.__class__ is DatasetColumn:
+                append.append(StringColumn(DATASET_NAME_COLUMN, '',
+                              self.DEFAULT_COLUMN_SIZE, list()))
+                # Ensure DatasetColumn is named 'Dataset'
+                column.name = "Dataset"
             # If image/roi name, then add ID column"
             if column.name == IMAGE_NAME_COLUMN:
                 append.append(ImageColumn("Image", '', list()))


### PR DESCRIPTION
## Changes
- This PR adds support to `DatasetColumn`, specifically support to a Dataset ID column

- This PR adds an option CLI `--detect_header` parameter to `omero metatdata populate` that automatically detects `column_type`. This aims to reduce the workload and remove the need for users to predefine the header types through automation.

Dataset ID column was necessary so that the `--detect_header` is easier and better implemented.

Tests passed locally with no failures.

Edit: Changed the default behavior to use the detect header method unless the user supplies a CSV with a custom header with `# header` or the new `--manual_header` flag. 

To do:

- [ ] Update README.md to reflect proper use of `--detect_header`
- [x] Fix other contexts when using `--detect_header`