### PR TITLE
Skip empty rows

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1314,7 +1314,7 @@ class ParsingContext(object):
                             column.values = []
                         row_count = 0
                 else:
-                    log.info('Skip empty row %d', r + 1)
+                    log.warning('Skip empty row %d', r + 1)
         if row_count != 0:
             log.debug("DATA TO ADD")
             log.debug(self.columns)
@@ -1347,7 +1347,7 @@ class ParsingContext(object):
             if row:
                 self.populate_row(row)
             else:
-                log.info('Skip empty row %d', r + 1)
+                log.warning('Skip empty row %d', r + 1)
 
     def post_process(self):
         target_class = self.target_object.__class__

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1304,14 +1304,17 @@ class ParsingContext(object):
         for (r, row) in enumerate(reader):
             log.debug('Row %d', r)
             if filter_function(row):
-                self.populate_row(row)
-                row_count = row_count + 1
-                if row_count >= batch_size:
-                    self.post_process()
-                    table.addData(self.columns)
-                    for column in self.columns:
-                        column.values = []
-                    row_count = 0
+                if row:
+                    self.populate_row(row)
+                    row_count = row_count + 1
+                    if row_count >= batch_size:
+                        self.post_process()
+                        table.addData(self.columns)
+                        for column in self.columns:
+                            column.values = []
+                        row_count = 0
+                else:
+                    log.info('Skip empty row %d', r + 1)
         if row_count != 0:
             log.debug("DATA TO ADD")
             log.debug(self.columns)
@@ -1341,7 +1344,10 @@ class ParsingContext(object):
         nrows = len(rows)
         for (r, row) in enumerate(rows):
             log.debug('Row %d/%d', r + 1, nrows)
-            self.populate_row(row)
+            if row:
+                self.populate_row(row)
+            else:
+                log.info('Skip empty row %d', r + 1)
 
     def post_process(self):
         target_class = self.target_object.__class__


### PR DESCRIPTION
Simply skip empty lines instead of crashing. Ran into this issue as well. Initially thought it's a linebreak at the end of the last entry, but that works fine actually. In order to replicate the issue you really need an empty line with a linebreak at the end of the file. As a side effect with the PR you can also have empty lines somewhere inbetween, they too will just be ignored.
Fixes https://github.com/ome/omero-metadata/issues/21 .
