### PR TITLE
Fix header detection for tables with sparse numerical data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,9 @@ Example Float   ``DoubleColumn``  ``d``
 Example boolean ``BoolColumn``    ``b``      
 =============== ================= ====================
 
+In the case of missing values, the column will be detected as ``StringColumn`` by default. If ``--allow-nan`` is passed to the
+``omero metadata populate`` commands, missing values in floating-point columns will be detected as ``DoubleColumn`` and the
+missing values will be stored as NaN.
 
 However, it is possible to manually define the header types, ignoring the automatic header detection, if a ``CSV`` with a ``# header`` row is passed. The ``# header`` row should be the first row of the CSV and defines columns according to the following list (see examples below):
 

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -241,11 +241,13 @@ class MetadataControl(BaseControl):
         populate.add_argument("--localcfg", help=(
             "Local configuration file or a JSON object string"))
 
-        populate.add_argument("--allow_nan", action="store_true", help=(
-            "Allow empty values to become Nan in Long or Double columns"))
+        populate.add_argument(
+           "--allow-nan", "--allow_nan", action="store_true", help=(
+                "Allow empty values to become Nan in Long or Double columns"))
 
-        populate.add_argument("--manual_header", action="store_true", help=(
-            "Disable automatic header detection during population"))
+        populate.add_argument(
+            "--manual-header", "--manual_header", action="store_true", help=(
+                "Disable automatic header detection during population"))
 
         populateroi.add_argument(
             "--measurement", type=int, default=None,

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -489,7 +489,7 @@ class MetadataControl(BaseControl):
             self.ctx.die(100, "Failed to initialize Table")
 
     @staticmethod
-    def detect_headers(csv_path):
+    def detect_headers(csv_path, keep_default_na=True):
         '''
         Function to automatically detect headers from a CSV file. This function
         loads the table to pandas to detects the column type and match headers
@@ -497,7 +497,7 @@ class MetadataControl(BaseControl):
 
         conserved_headers = ['well', 'plate', 'image', 'dataset', 'roi']
         headers = []
-        table = pd.read_csv(csv_path)
+        table = pd.read_csv(csv_path, keep_default_na=keep_default_na)
         col_types = table.dtypes.values.tolist()
         cols = list(table.columns)
 

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -579,7 +579,8 @@ class MetadataControl(BaseControl):
         if not args.manual_header and \
                 not first_row[0].str.contains('# header').bool():
             omero_metadata.populate.log.info("Detecting header types")
-            header_type = MetadataControl.detect_headers(args.file)
+            header_type = MetadataControl.detect_headers(
+                args.file, keep_default_na=args.allow_nan)
             if args.dry_run:
                 omero_metadata.populate.log.info(f"Header Types:{header_type}")
         else:

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -175,6 +175,13 @@ class Fixture(object):
         col_names = "Well,Well Type,Concentration,Well Name"
         assert col_names == ",".join([c.name for c in columns])
 
+    def assert_values(self, row_values):
+        # Unsure where the lower-casing is happening
+        if "A1" in row_values or "a1" in row_values:
+            assert "Control" in row_values
+        elif "A2" in row_values or "a2" in row_values:
+            assert "Treatment" in row_values
+
     def assert_child_annotations(self, oas):
         for ma, wid, wr, wc in oas:
             assert isinstance(ma, MapAnnotationI)
@@ -767,6 +774,14 @@ class Image2Rois(Fixture):
     def assert_row_count(self, rows):
         assert rows == len(self.roi_names)
 
+    def assert_values(self, row_values):
+        if "roi1" in row_values:
+            assert 0.5 in row_values
+            assert 100 in row_values
+        elif "roi2" in row_values:
+            assert 'nan' in [str(value) for value in row_values]
+            assert 200 in row_values
+
     def get_target(self):
         if not self.image:
             image = self.test.make_image()
@@ -1218,17 +1233,7 @@ class TestPopulateMetadataHelper(ITest):
             row_values = [col.values[0] for col in t.read(
                 list(range(len(cols))), hit, hit+1).columns]
             assert len(row_values) == fixture.count
-            # Unsure where the lower-casing is happening
-            if "A1" in row_values or "a1" in row_values:
-                assert "Control" in row_values
-            elif "A2" in row_values or "a2" in row_values:
-                assert "Treatment" in row_values
-            elif "roi1" in row_values:
-                assert 0.5 in row_values
-                assert 100 in row_values
-            elif "roi2" in row_values:
-                assert 'nan' in [str(value) for value in row_values]
-                assert 200 in row_values
+            fixture.assert_values(row_values)
 
     def _test_bulk_to_map_annotation_context(self, fixture, batch_size):
         # self._testPopulateMetadataPlate()

--- a/test/unit/test_automatic_header.py
+++ b/test/unit/test_automatic_header.py
@@ -19,11 +19,11 @@ from omero.grid import ImageColumn, LongColumn, PlateColumn, RoiColumn, \
 
 class TestDetectHeaders:
     """Test the MetadataControl.detect_headers API"""
-    def assert_detect_headers(self):
+    def assert_detect_headers(self, **kwargs):
         df = pd.DataFrame(data=self.d)
         tmp = tempfile.NamedTemporaryFile()
         df.to_csv(tmp.name, index=False)
-        header = MetadataControl.detect_headers(tmp.name)
+        header = MetadataControl.detect_headers(tmp.name, **kwargs)
         assert header == self.expected_header
 
     def create_objects_dictionary(self):
@@ -52,7 +52,7 @@ class TestDetectHeaders:
         self.create_objects_dictionary()
         self.assert_detect_headers()
 
-    def test_dense_extra_columns(self):
+    def test_dense_columns(self):
         '''
         Test of the default automatic column type detection behaviour
         '''
@@ -66,6 +66,34 @@ class TestDetectHeaders:
         })
         self.expected_header.extend(['l', 'd', 's', 'b', 's'])
         self.assert_detect_headers()
+
+    def test_sparse_default_na(self):
+        '''
+        Test default handling of missing values
+        '''
+        self.create_objects_dictionary()
+        self.d.update({
+            'measurement 1': [11, None, 33],
+            'measurement 2': [0.1, 0.2, None],
+            'measurement 3': ['a', 'b', None],
+            'measurement 4': [True, None, False],
+        })
+        self.expected_header.extend(['d', 'd', 's', 's'])
+        self.assert_detect_headers(keep_default_na=True)
+
+    def test_sparse_no_default_na(self):
+        '''
+        Test handling of missing values as string columns
+        '''
+        self.create_objects_dictionary()
+        self.d.update({
+            'measurement 1': [11, None, 33],
+            'measurement 2': [0.1, 0.2, None],
+            'measurement 3': ['a', 'b', None],
+            'measurement 4': [True, None, False],
+        })
+        self.expected_header.extend(['s', 's', 's', 's'])
+        self.assert_detect_headers(keep_default_na=False)
 
 
 class TestColumnTypes:


### PR DESCRIPTION
Fixes #76 

## Reproducible scenario

First create a minimal dataset/image hierarchy e.g. as follows:

```bash
touch test1.fake test2.fake
dataset=$(omero obj new Dataset name=sparse_table)
omero import -T $dataset test1.fake test2.fake
```

CSV files with sparse string data such as the one below are correctly handled by the current HEAD of `omero-metadata`.

```
$ cat sparse_string_column.csv 
Image name,meas1,meas2,meas3,meas4
test1.fake,1.1,1,high,low
test2.fake,0.5,2,,low
```

The columns with missing values are mapped as `s/StringCOlumn` and the missing value are turned into empty strings where running `omero metadata populate --file sparse_string_column.csv $dataset` e.g.

CSV files with sparse numerical columns such as the one below currently fail during the population command:

```csv
$ cat sparse_numeric_column.csv
Image name,meas1,meas2,meas3,meas4
test1.fake,1.1,1.2,high,low
test2.fake,,2.1,,low
```

Here, the `meas1` column is currently mapped into a `d` header type/`DoubleColumn` by the `pandas` detection logic, With the default `omero metadata populate --file command, the table population fails with `ValueError: Empty Double or Long value. Use --allow_nan to convert to NaN`.

## Proposed changes

Since the library already includes some logic allowing the user to control whether NaN values are allowed in the OMERO.table (introduced in #60), this PR proposes the following changes

- the `MetadataControl.detect_headers` API supports an extra `keep_default_na` argument (`True` by default)`. Its value is forwarded to `pandas.read_csv` and determines controls how pandas should handle NA (missing) values and whether the column is detected as `d` vs `s` (see https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html)
- unit tests are added to cover the new `MetadataControl.detect_headers` API with different combination of tables/arguments
- the populate command is updated to use the value of `args.allow_nan` (`False` by default) as pass it as  `keep_default_na` to `MetadataControl.detect_headers` 

fe73a17d2a71fd7d220c48891a2364110b59f4f1 adds a cosmetic change defining GNU-style aliases of the command-line arguments (`--manual-header`, `--allow-nan`) using hyphen as separator. The existing underscore separated flags are preserved.

## Testing

With these changes, annotating of sparse CSV tables using the default header detection should be functional in all cases.

1. if the tabular data is dense or containing sparse string columns, the behavior of the command should be unchanged 
2. if the tabular data is dense or containing sparse numerical columns,, the behavior of the command  will depend on the  `--allow-nan` flag

   ```
   omero metadata populate --file sparse_numeric_column.csv $data
   ```
   will detect the sparse numeric column as a`StringColumn` and store the missing values as empty strings

   ```
   omero metadata populate --file sparse_numeric_column.csv --allow-nan $data
   ```
   will detect the sparse numeric column as a `DoubleColumn` and store missing values as `nan`