### PR TITLE
"Nothing to do during post processing." from info to debug

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1401,7 +1401,7 @@ class ParsingContext(object):
         if well_name_column is None and plate_name_column is None \
                 and image_name_column is None and roi_name_column is None \
                 and roi_column is None:
-            log.info('Nothing to do during post processing.')
+            log.debug('Nothing to do during post processing.')
             return
 
         sz = max([len(x.values) for x in self.columns])


### PR DESCRIPTION
This particular line is creating as many entries in the log file as there is rows in the table! This is particularly bad in the case where number of rows in the tables reach >100k.

If there's no particular reason to keep it at the info level it would be great to change it to debug.