### PR TITLE
Only perform header detection when --file is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.11.2
+------
+
+* Only perform header detection when --file is specified ([#80](https://github.com/ome/omero-metadata/pull/80))
+
 0.11.1
 ------
 

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -572,19 +572,20 @@ class MetadataControl(BaseControl):
                 md.linkAnnotation(cfgann)
 
         header_type = None
-        # To use auto detect header by default unless instructed not to
-        # AND
-        # Check if first row contains `# header`
-        first_row = pd.read_csv(args.file, nrows=1, header=None)
-        if not args.manual_header and \
-                not first_row[0].str.contains('# header').bool():
-            omero_metadata.populate.log.info("Detecting header types")
-            header_type = MetadataControl.detect_headers(
-                args.file, keep_default_na=args.allow_nan)
-            if args.dry_run:
-                omero_metadata.populate.log.info(f"Header Types:{header_type}")
-        else:
-            omero_metadata.populate.log.info("Using user defined header types")
+        if args.file:
+            # To use auto detect header by default unless instructed not to
+            # AND
+            # Check if first row contains `# header`
+            first_row = pd.read_csv(args.file, nrows=1, header=None)
+            if not args.manual_header and \
+                    not first_row[0].str.contains('# header').bool():
+                omero_metadata.populate.log.info("Detecting header types")
+                header_type = MetadataControl.detect_headers(
+                    args.file, keep_default_na=args.allow_nan)
+                if args.dry_run:
+                    omero_metadata.populate.log.info(f"Header Types:{header_type}")
+            else:
+                omero_metadata.populate.log.info("Using user defined header types")
         loops = 0
         ms = 0
         wait = args.wait

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -583,9 +583,11 @@ class MetadataControl(BaseControl):
                 header_type = MetadataControl.detect_headers(
                     args.file, keep_default_na=args.allow_nan)
                 if args.dry_run:
-                    omero_metadata.populate.log.info(f"Header Types:{header_type}")
+                    omero_metadata.populate.log.info(
+                        f"Header Types:{header_type}")
             else:
-                omero_metadata.populate.log.info("Using user defined header types")
+                omero_metadata.populate.log.info(
+                    "Using user defined header types")
         loops = 0
         ms = 0
         wait = args.wait


### PR DESCRIPTION
This PR attempts to fix a regression introduced as part of https://github.com/ome/omero-metadata/pull/67 which was primarily tested with the `omero metadata populate` command

To reproduce, run a workflow composed of a table population followed by a bulk annotation -> map annotation population, for instance as described with https://omero-guides.readthedocs.io/en/latest/upload/docs/metadata.html.

With the current release of `omero-metadata 0.11.1`, the second step should fail with and error of type

```
$ omero metadata populate --context bulkmap --cfg simple-annotation-bulkmap-config.yml Dataset:601
Using session for import.user@localhost:4064. Idle timeout: 10 min. Current group: Demo Group
Traceback (most recent call last):
  File "/opt/omero/OMERO.venv/bin/omero", line 8, in <module>
    sys.exit(main())
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/omero/main.py", line 126, in main
    rv = omero.cli.argv()
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/omero/cli.py", line 1787, in argv
    cli.invoke(args[1:])
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/omero/cli.py", line 1225, in invoke
    stop = self.onecmd(line, previous_args)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/omero/cli.py", line 1302, in onecmd
    self.execute(line, previous_args)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/omero/cli.py", line 1384, in execute
    args.func(args)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/omero_metadata/cli.py", line 578, in populate
    first_row = pd.read_csv(args.file, nrows=1, header=None)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/util/_decorators.py", line 211, in wrapper
    return func(*args, **kwargs)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/util/_decorators.py", line 331, in wrapper
    return func(*args, **kwargs)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py", line 950, in read_csv
    return _read(filepath_or_buffer, kwds)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py", line 605, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py", line 1442, in __init__
    self._engine = self._make_engine(f, self.engine)
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py", line 1735, in _make_engine
    self.handles = get_handle(
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/io/common.py", line 713, in get_handle
    ioargs = _get_filepath_or_buffer(
  File "/opt/omero/OMERO.venv/lib/python3.8/site-packages/pandas/io/common.py", line 451, in _get_filepath_or_buffer
    raise ValueError(msg)
ValueError: Invalid file path or buffer object type: <class 'NoneType'>
```

With this PR included, both population steps should successfully complete.

Given the regression, I would propose to schedule this in an upcoming patch release `0.11.2` (possibly together with #79)