### PR TITLE
Update ParsingContext.parse() to return the ID of the table

### DIFF
--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -1184,12 +1184,12 @@ class ParsingContext(object):
             self.populate_from_reader(reader,
                                       self.filter_function, table, 1000)
             self.create_file_annotation(table)
+            log.debug('Column widths: %r' % self.get_column_widths())
+            log.debug('Columns: %r' % [
+                (o.name, len(o.values)) for o in self.columns])
+            return table.getOriginalFile().id.val
         finally:
             table.close()
-
-        log.debug('Column widths: %r' % self.get_column_widths())
-        log.debug('Columns: %r' % [
-            (o.name, len(o.values)) for o in self.columns])
 
     def create_table(self):
         sf = self.client.getSession()

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -1204,7 +1204,7 @@ class TestPopulateMetadataHelper(ITest):
                 ctx.parse()
             return
         else:
-            ctx.parse()
+            out = ctx.parse()
 
         # Get file annotations
         anns = fixture.get_annotations()
@@ -1213,6 +1213,7 @@ class TestPopulateMetadataHelper(ITest):
         table_file_ann = anns[0]
         assert unwrap(table_file_ann.getNs()) == NSBULKANNOTATIONS
         fileid = table_file_ann.file.id.val
+        assert fileid == out
 
         # Load file to check name
         query = self.client.sf.getQueryService()


### PR DESCRIPTION
Comes from a discussion with @muhanadz. For scenarios where the `omero-metadata` plugin is used as a Python library, it is currently a requirement to make an additional query to retrieve the table created by `omero_metadata.populate.ParsingContext.parse()` operation.

As the implementation passes through the return value of `parse_from_handle_stream` https://github.com/ome/omero-metadata/blob/0ea482289812abf6adc58e13d2a49f71874d51d9/src/omero_metadata/populate.py#L1208-L1218, this PR amends the latter API to return the ID of the original file associated with the OMERO.table.

The unit tests are also amended to compare the output of the `parse()` API with the query and give an example of how a consumer might use the new functionality.