### PR TITLE
Integration tests: call pytest directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,70 +18,8 @@
 #
 #
 import os
-import sys
 
 from setuptools import setup
-from setuptools.command.test import test as test_command
-
-
-class PyTest(test_command):
-    user_options = [
-        ('test-path=', 't', "base dir for test collection"),
-        ('test-ice-config=', 'i',
-         "use specified 'ice config' file instead of default"),
-        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-        ('test-string=', 'k', "only run tests matching 'string'"),
-        ('test-marker=', 'm', "only run tests including 'marker'"),
-        ('test-no-capture', 's', "don't suppress test output"),
-        ('test-failfast', 'x', "Exit on first error"),
-        ('test-verbose', 'v', "more verbose output"),
-        ('test-quiet', 'q', "less verbose output"),
-        ('junitxml=', None, "create junit-xml style report file at 'path'"),
-        ('pdb', None, "fallback to pdb on error"),
-        ]
-
-    def initialize_options(self):
-        test_command.initialize_options(self)
-        self.test_pythonpath = None
-        self.test_string = None
-        self.test_marker = None
-        self.test_path = 'test'
-        self.test_failfast = False
-        self.test_quiet = False
-        self.test_verbose = False
-        self.test_no_capture = False
-        self.junitxml = None
-        self.pdb = False
-        self.test_ice_config = None
-
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = [self.test_path]
-        if self.test_string is not None:
-            self.test_args.extend(['-k', self.test_string])
-        if self.test_marker is not None:
-            self.test_args.extend(['-m', self.test_marker])
-        if self.test_failfast:
-            self.test_args.extend(['-x'])
-        if self.test_verbose:
-            self.test_args.extend(['-v'])
-        if self.test_quiet:
-            self.test_args.extend(['-q'])
-        if self.junitxml is not None:
-            self.test_args.extend(['--junitxml', self.junitxml])
-        if self.pdb:
-            self.test_args.extend(['--pdb'])
-        self.test_suite = True
-        if 'ICE_CONFIG' not in os.environ:
-            os.environ['ICE_CONFIG'] = self.test_ice_config
-
-    def run_tests(self):
-        if self.test_pythonpath is not None:
-            sys.path.insert(0, self.test_pythonpath)
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 def read(fname):
@@ -122,7 +60,6 @@ setup(
     zip_safe=True,
     download_url='%s/v%s.tar.gz' % (url, version),
     keywords=['OMERO.CLI', 'plugin'],
-    cmdclass={'test': PyTest},
     install_requires=[
         'omero-py>=5.6.0',
         'PyYAML',

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ setup(
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
     install_requires=[
-        'future',
         'omero-py>=5.6.0',
         'PyYAML',
         'jinja2',

--- a/src/omero_metadata/cli.py
+++ b/src/omero_metadata/cli.py
@@ -7,13 +7,8 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
-from __future__ import division
 
 import omero_ext.argparse as argparse
-from builtins import str
-from builtins import range
-from builtins import object
-from future.utils import native_str
 import logging
 import mimetypes
 import os
@@ -734,5 +729,5 @@ class MetadataControl(BaseControl):
                 pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit))
 
         group_id = pixels[0].getDetails().getGroup().getId().getValue()
-        ctx = {'omero.group': native_str(group_id)}
+        ctx = {'omero.group': str(group_id)}
         conn.getUpdateService().saveArray(pixels, ctx)

--- a/src/omero_metadata/populate.py
+++ b/src/omero_metadata/populate.py
@@ -3,7 +3,6 @@
 """
 Populate bulk metadata tables from delimited text files.
 """
-from __future__ import print_function
 
 #
 #  Copyright (C) 2011-2019 University of Dundee. All rights reserved.
@@ -24,12 +23,6 @@ from __future__ import print_function
 #
 
 
-from builtins import chr
-from builtins import str
-from builtins import range
-from future.utils import native_str
-from past.builtins import basestring
-from builtins import object
 import logging
 import gzip
 import sys
@@ -1197,7 +1190,7 @@ class ParsingContext(object):
         group = str(self.value_resolver.target_group)
         sr = sf.sharedResources()
         table = sr.newTable(1, self.table_name,
-                            {'omero.group': native_str(group)})
+                            {'omero.group': str(group)})
         if table is None:
             raise MetadataError(
                 "Unable to create table: %s" % DEFAULT_TABLE_NAME)
@@ -1235,7 +1228,7 @@ class ParsingContext(object):
                     break
                 try:
                     log.debug("Value's class: %s" % value.__class__)
-                    if isinstance(value, basestring):
+                    if isinstance(value, str):
                         column.size = max(
                             column.size, len(value.encode('utf-8')))
                     # The following IDs are needed for
@@ -1339,7 +1332,7 @@ class ParsingContext(object):
         link = self.create_annotation_link()
         link.parent = self.target_object
         link.child = file_annotation
-        update_service.saveObject(link, {'omero.group': native_str(group)})
+        update_service.saveObject(link, {'omero.group': str(group)})
 
     def populate(self, rows):
         nrows = len(rows)
@@ -1602,7 +1595,7 @@ class _QueryContext(object):
             nids = 1
             single_id = ids
 
-        if isinstance(nss, basestring):
+        if isinstance(nss, str):
             params.addString("ns", nss)
         elif nss:
             params.map['nss'] = rlist(rstring(s) for s in nss)
@@ -1804,7 +1797,7 @@ class BulkToMapAnnotationContext(_QueryContext):
         group = str(self.target_object.details.group.id)
         update_service = sf.getUpdateService()
         arr = update_service.saveAndReturnArray(
-            links, {'omero.group': native_str(group)})
+            links, {'omero.group': str(group)})
         return arr
 
     def _save_annotation_and_links(self, links, ann, batch_size):
@@ -1829,7 +1822,7 @@ class BulkToMapAnnotationContext(_QueryContext):
             for link in batch:
                 link.setChild(annobj)
             update_service.saveArray(
-                batch, {'omero.group': native_str(group)})
+                batch, {'omero.group': str(group)})
             sz += len(batch)
         return sz
 

--- a/test/integration/clitest/test_metadata.py
+++ b/test/integration/clitest/test_metadata.py
@@ -20,7 +20,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import pytest
-from past.builtins import long
 
 import omero
 import omero.gateway
@@ -43,7 +42,7 @@ class MetadataTestBase(CLITest):
 
         conn = BlitzGateway(client_obj=self.client)
         self.imageid = unwrap(self.image.getId())
-        assert isinstance(self.imageid, long)
+        assert isinstance(self.imageid, int)
         wrapper = conn.getObject("Image", self.imageid)
         self.md = Metadata(wrapper)
 

--- a/test/integration/clitest/test_metadata.py
+++ b/test/integration/clitest/test_metadata.py
@@ -245,9 +245,10 @@ class TestMetadataControl(MetadataTestBase):
         o = self.invoke(capfd)
         assert "FileAnnotation:" in o
 
-        # Should have no FileAnnotation since it's deleted
+        # Should be empty since it's deleted
         o = self.invoke(capfd)
-        assert "FileAnnotation:" not in o
+        assert o == ""
+        assert len(o.strip()) == 0
 
     @pytest.mark.parametrize('report', [False, True])
     def test_measures(self, capfd, report):

--- a/test/integration/metadata/test_populate.py
+++ b/test/integration/metadata/test_populate.py
@@ -24,10 +24,6 @@
    and populate_roi.py scripts.
 """
 
-from builtins import str
-from builtins import zip
-from builtins import range
-from builtins import object
 from omero.testlib import ITest
 import string
 import csv

--- a/test/integration/tablestest/test_populate_metadata.py
+++ b/test/integration/tablestest/test_populate_metadata.py
@@ -24,7 +24,6 @@
 
 """
 
-from builtins import range
 from omero.testlib import ITest
 import os
 


### PR DESCRIPTION
See https://github.com/ome/omero-metadata/pull/84#issuecomment-1888767870

Following the upgrade of the test infrastructure to Rocky Linux 9/Python 3.9 (see https://github.com/ome/omero-test-infra/pull/66), some of the tests started failing due to the presence of logging statements in the stdout conflicting with some of the `assert` checks.
After some investigation, this behavioral change does not look to be related to the operating system or Python version per se but is more specific to the testing infrastructure.

These changes depend on https://github.com/ome/omero-test-infra/pull/68 to call `pytest` directly instead of `python setup.py test` and revert a11343c71bf89d4d116137e1db96dff7e54e51ee.