### PR TITLE
Cap pandas to 2.x and clean up unused dependencies

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       STAGE: cli
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Checkout omero-test-infra
         uses: actions/checkout@master
         with:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Build a binary wheel and a source tarball

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ management of annotations on objects in OMERO.
 Requirements
 ============
 
-* OMERO 5.6.0 or newer
-* Python 3.6 or newer
+* OMERO 5.6.x
+* Python 3.10+
 
 
 Installing from PyPI

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'omero-py>=5.6.0',
         'pandas>=2,<3'
     ],
-    python_requires='>=3',
+    python_requires='>=3.10',
     tests_require=[
         'omero-py>=5.17.0',
         'pytest'],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'omero-py>=5.6.0',
         'PyYAML',
         'jinja2',
-        'pandas'
+        'pandas>=2,<3'
     ],
     python_requires='>=3',
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ setup(
     keywords=['OMERO.CLI', 'plugin'],
     install_requires=[
         'omero-py>=5.6.0',
-        'PyYAML',
-        'jinja2',
         'pandas>=2,<3'
     ],
     python_requires='>=3',


### PR DESCRIPTION
Fixes #93 

- caps `pandas` to 2.x - the support of Pandas 3.x will need to be evaluated separately
- removes the unused `Jinja2` and `PyYAML` dependencies - probably a legacy from the old population code in `omero-py`
- bumps the minimum version of Python to 3.10. Pandas 2.x mandates Python 3.8+ but 3.8 and 3.9 are already EOL